### PR TITLE
Python 3 Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+build
 dist
 *.swp
 *.swo
 *.pyc
 *__pycache__*
+*.egg-info
 xcffib

--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -388,7 +388,7 @@ processXDecl ext (XidType name) =
   do modify $ mkModify ext name (BaseType "I")
      return Noop
 processXDecl _ (XImport n) =
-  return $ Declaration [mkImport n]
+  return $ Declaration [ mkRelImport n]
 processXDecl _ (XEnum name membs) =
   return $ Declaration [mkEnum name $ xEnumElemsToPyEnum id membs]
 processXDecl ext (XStruct n membs) = do

--- a/generator/Data/XCB/Python/PyHelpers.hs
+++ b/generator/Data/XCB/Python/PyHelpers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 module Data.XCB.Python.PyHelpers (
   mkImport,
+  mkRelImport,
   mkInt,
   mkAssign,
   mkCall,
@@ -70,6 +71,9 @@ mkAttr s = mkName ("self." ++ s)
 
 mkImport :: String -> Statement ()
 mkImport name = Import [ImportItem (mkDottedName name) Nothing ()] ()
+
+mkRelImport :: String -> Statement ()
+mkRelImport name = FromImport (ImportRelative 1 Nothing ()) (FromItems [FromItem (ident name) Nothing ()] ()) ()
 
 mkInt :: Int -> Expr ()
 mkInt i = Int (toInteger i) (show i) ()

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, absolute_import
 
 import functools
 import six


### PR DESCRIPTION
I'll admit my Haskell is lacking compared to my Python, but here is my attempt at this fix.

Make relative imports use the Python 3 style absolute imports:

```
from . import xxx
```
