### PR TITLE
Fix strange seg fault in Python 3.4

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -351,11 +351,11 @@ class Connection(object):
         after the function is invoked.
         """
         @functools.wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args):
             self = args[0]
             self.invalid()
             try:
-                return f(*args, **kwargs)
+                return f(*args)
             finally:
                 self.invalid()
         return wrapper


### PR DESCRIPTION
Not sure why this seg faults, it's probably some error with Python, but it will seg fault when `**kwargs` are passed. Since none of the functions that are wrapped use `kwargs`, it is alright to drop them.
