### PR TITLE
Propery encode char arrays

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -514,16 +514,19 @@ def pack_list(from_, pack_type):
     `struct.pack`. You must pass `size` if `pack_type` is a struct.pack string.
     """
 
-    if six.PY3:
-        # If a string is passed as `from_`, it has to be encoded as a list of
-        # bytes (see py3 problem below)
-        if isinstance(from_, str):
-            from_ = [bytes(b, 'latin1') for b in from_]
-        # PY3 is "helpful" in that when you do tuple(b'foo') you get
-        # (102, 111, 111) instead of something more reasonable like
-        # (b'f', b'o', b'o'), so we have to add this other special case.
-        elif isinstance(from_, bytes):
-            from_ = [bytes([b]) for b in from_]
+    # If a string is passed as `from_` in Python 3, it has to be encoded
+    if six.PY3 and isinstance(from_, str):
+        from_ = from_.encode('latin1')
+
+    # Pack from_ as char array, where from_ may be an array of ints
+    if pack_type == 'c':
+        from_ = bytes(bytearray(from_))
+
+    # PY3 is "helpful" in that when you do tuple(b'foo') you get
+    # (102, 111, 111) instead of something more reasonable like
+    # (b'f', b'o', b'o'), so we have to add this other special case.
+    if six.PY3 and isinstance(from_, bytes):
+        from_ = [bytes([b]) for b in from_]
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *tuple(from_))


### PR DESCRIPTION
Some calls to pack_list give integer arrays to pack as characters (such
as ChangeProperty, which takes an array of atom values).  This properly
encodes the input data so it can be packed and adds tests, some of which
would otherwise fail.
