### PR TITLE
More char packing

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -530,24 +530,15 @@ def pack_list(from_, pack_type):
     `struct.pack`. You must pass `size` if `pack_type` is a struct.pack string.
     """
 
-    # If a string is passed as `from_` in Python 3, it has to be encoded
-    if isinstance(from_, str):
-        from_ = from_.encode('latin1')
-    # Pack from_ as char array, where from_ may be an array of ints possibly
-    # greater than 256
-    elif pack_type == 'c':
-        def to_bytes(v):
-            for _ in range(4):
-                v, r = divmod(v, 256)
-                yield r
-            raise StopIteration
-        from_ = bytes(bytearray([b for i in from_ for b in to_bytes(i)]))
-
-    # PY3 is "helpful" in that when you do tuple(b'foo') you get
-    # (102, 111, 111) instead of something more reasonable like
-    # (b'f', b'o', b'o'), so we have to add this other special case.
-    if six.PY3 and isinstance(from_, bytes):
-        from_ = [bytes([b]) for b in from_]
+    if six.PY3:
+        # If a string is passed as `from_` in Python 3, it has to be encoded
+        if isinstance(from_, str):
+            from_ = from_.encode('latin1')
+        # PY3 is "helpful" in that when you do tuple(b'foo') you get
+        # (102, 111, 111) instead of something more reasonable like
+        # (b'f', b'o', b'o'), so we have to add this other special case.
+        if isinstance(from_, bytes):
+            from_ = [bytes([b]) for b in from_]
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *tuple(from_))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -186,7 +186,8 @@ class TestConnection(XvfbTest):
                 len(title), title)
 
         reply = self.xproto.GetProperty(False, wid,
-                xcffib.xproto.Atom.WM_NAME, xcffib.xproto.GetPropertyType.Any, 0, 1).reply()
+                xcffib.xproto.Atom.WM_NAME,
+                xcffib.xproto.GetPropertyType.Any, 0, 1).reply()
         assert b''.join(reply.value).decode() == title
 
     def test_ChangeProperty_WM_PROTOCOLS(self):
@@ -194,22 +195,26 @@ class TestConnection(XvfbTest):
         self.create_window(wid=wid)
 
         wm_protocols = "WM_PROTOCOLS"
-        wm_protocols = self.xproto.InternAtom(0, len(wm_protocols), wm_protocols).reply().atom
+        wm_protocols = self.xproto.InternAtom(0, len(wm_protocols),
+                wm_protocols).reply().atom
 
         wm_delete_window = "WM_DELETE_WINDOW"
-        wm_delete_window = self.xproto.InternAtom(0, len(wm_delete_window), wm_delete_window).reply().atom
+        wm_delete_window = self.xproto.InternAtom(0, len(wm_delete_window),
+                wm_delete_window).reply().atom
 
         self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
                 wm_protocols, xcffib.xproto.Atom.ATOM, 32,
-                1, (wm_delete_window,))
+                1, struct.pack("=I", wm_delete_window))
 
-        reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
+        reply = self.xproto.GetProperty(False, wid,
+                wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
 
         assert reply.value.to_atoms() == (wm_delete_window,)
 
     def test_GetAtomName(self):
         wm_protocols = "WM_PROTOCOLS"
-        atom = self.xproto.InternAtom(0, len(wm_protocols), wm_protocols).reply().atom
+        atom = self.xproto.InternAtom(0, len(wm_protocols),
+                wm_protocols).reply().atom
         atom_name = self.xproto.GetAtomName(atom).reply().name
 
         assert atom_name.to_string() == wm_protocols


### PR DESCRIPTION
Pack ints when they are >= 256 (`bytes([i])` and `bytearray([i])` can't do it) and pack ints as 4 bytes in all cases. This assumes that if something is packed as `'c'` and is not a string, it is an int, which I'm not sure of, but is the case for things like atoms, and so is necessary for actions like doing `ChangeProperty` (which packs atoms (i.e. ints) to `'c'`) to set `WM_PROTOCOLS`.
