### PR TITLE
Check `thing` is a class before checking `issubclass(...)`

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -51,7 +51,7 @@ class Unpacker(object):
             self.buf = ffi.buffer(self.cdata, self.size)
 
     def pad(self, thing):
-        if any([issubclass(thing, c) for c in [Struct, Union]]):
+        if isinstance(thing, type) and any([issubclass(thing, c) for c in [Struct, Union]]):
             if hasattr(thing, "fixed_size"):
                 size = thing.fixed_size
             else:


### PR DESCRIPTION
Needed when `thing` is a string, like `"c"` or `"I"`(as in the generated `xcffib/randr.py` class `GetScreenResolutionReply`)
