### PR TITLE
Decode bytes output from subprocess.check_output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class cffi_build(build):
         self.distribution.ext_modules = [xcffib.ffi.verifier.get_extension()]
         build.finalize_options(self)
 
-version = subprocess.check_output(['git', 'describe', '--tags'])
+version = subprocess.check_output(['git', 'describe', '--tags']).decode()
 dependencies = ['six', 'cffi>=0.8.2']
 
 setup(


### PR DESCRIPTION
Python 3 sends output back as bytes, so it needs to be decoded to a string.
