### PR TITLE
Another explicit lifetime fix

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -547,11 +547,9 @@ class Connection(object):
         buf = Unpacker(e)
         return event(buf)
 
+    @ensure_connected
     def send_request(self, flags, xcb_parts, xcb_req):
-        self.invalid()
-        ret = C.xcb_send_request(self._conn, flags, xcb_parts, xcb_req)
-        self.invalid()
-        return ret
+        return C.xcb_send_request(self._conn, flags, xcb_parts, xcb_req)
 
 
 # More backwards compatibility


### PR DESCRIPTION
Add another explicit lifetime for `xcb_parts[0].iov_base`. This is the only other place (I think) we use `ffi.new()` and need to hold on to pointers explicitly, and all our uses of `ffi.cast()` look like they shouldn't suffer from having the memory deleted out from under them.

Also, re-enable the `@ensure_connected` decorator on send request. I'm able to run qtile on this xcffib with the decorator, and all the qtile tests can pass on this (!!!!! https://travis-ci.org/flacjacket/qtile/builds/32488003) which is very rare, that is the second time I've seen all qtile tests pass on the cffi branch. Maybe we should have roger try it out, too?
