### PR TITLE
Catch longs for packing in pack_list

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -683,7 +683,7 @@ def pack_list(from_, pack_type):
             # Only run in Python 3, where bytes are different than strings
             # Here we create the tuple of bytes by encoding each character
             from_ = [b.encode('latin-1') for b in from_]
-        elif isinstance(from_[0], int):
+        elif isinstance(from_[0], six.integer_types):
             # Pack from_ as char array, where from_ may be an array of ints
             # possibly greater than 256
             def to_bytes(v):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -190,6 +190,11 @@ class TestConnection(XcffibTest):
         self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
                 wm_protocols, xcffib.xproto.Atom.ATOM, 32,
                 1, (wm_delete_window,))
+        # For Python 2 only, make sure packing can handle both ints and longs
+        if six.PY2:
+            self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
+                    wm_protocols, xcffib.xproto.Atom.ATOM, 32,
+                    1, (long(wm_delete_window),))
 
         reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
 


### PR DESCRIPTION
When, for example, id's are generated in python 2, they are 32-bit
unsigned values, and so are returned as long's. This properly catches
longs for conversion to byte arrays when packing.
