### PR TITLE
Bump to use CFFI-1.0 compatible compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ python:
   - pypy
   - pypy3
 
+matrix:
+  allow_failures:
+    - python: pypy
+    - python: pypy3
+
 before_install:
   - sudo apt-get update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ python:
   - pypy
   - pypy3
 
-matrix:
-  allow_failures:
-    - python: pypy
-    - python: pypy3
-
 before_install:
   - sudo apt-get update
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ xcffib: $(GEN) module/*.py
 	$(GEN) --input $(XCBDIR) --output ./xcffib
 	cp ./module/*py ./xcffib/
 	sed -i "s/__xcb_proto_version__ = .*/__xcb_proto_version__ = \"${XCBVER}\"/" xcffib/__init__.py
+	python setup.py build_ext --inplace
 
 .PHONY: xcffib-fmt
 xcffib-fmt: $(GEN) module/*.py

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -23,8 +23,8 @@ import weakref
 try:
     from xcffib._ffi import ffi, lib
 except ImportError:
-    raise ImportError("Unable to import ffi module, re-generate xcffib "
-                      "by running `make xcffib`")
+    from xcffib.ffi_build import ffi, SOURCE
+    lib = ffi.verify(SOURCE, libraries=['xcb'], ext_package='xcffib')
 # We're just re-exporting visualtype_to_c_struct, hence the noqa.
 from xcffib.ffi_build import visualtype_to_c_struct  # noqa
 

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -20,18 +20,23 @@ import six
 import struct
 import weakref
 
+try:
+    from xcffib._ffi import ffi, lib
+except ImportError:
+    raise ImportError("Unable to import ffi module, re-generate xcffib "
+                      "by running `make xcffib`")
 # We're just re-exporting visualtype_to_c_struct, hence the noqa.
-from .ffi import ffi, C, visualtype_to_c_struct  # noqa
+from xcffib.ffi_build import visualtype_to_c_struct  # noqa
 
 __xcb_proto_version__ = 'placeholder'
 
-X_PROTOCOL = C.X_PROTOCOL
-X_PROTOCOL_REVISION = C.X_PROTOCOL_REVISION
+X_PROTOCOL = lib.X_PROTOCOL
+X_PROTOCOL_REVISION = lib.X_PROTOCOL_REVISION
 
-XCB_NONE = C.XCB_NONE
-XCB_COPY_FROM_PARENT = C.XCB_COPY_FROM_PARENT
-XCB_CURRENT_TIME = C.XCB_CURRENT_TIME
-XCB_NO_SYMBOL = C.XCB_NO_SYMBOL
+XCB_NONE = lib.XCB_NONE
+XCB_COPY_FROM_PARENT = lib.XCB_COPY_FROM_PARENT
+XCB_CURRENT_TIME = lib.XCB_CURRENT_TIME
+XCB_NO_SYMBOL = lib.XCB_NO_SYMBOL
 
 # For xpyb compatibility
 NONE = XCB_NONE
@@ -39,13 +44,13 @@ CopyFromParent = XCB_COPY_FROM_PARENT
 CurrentTime = XCB_CURRENT_TIME
 NoSymbol = XCB_NO_SYMBOL
 
-XCB_CONN_ERROR = C.XCB_CONN_ERROR
-XCB_CONN_CLOSED_EXT_NOTSUPPORTED = C.XCB_CONN_CLOSED_EXT_NOTSUPPORTED
-XCB_CONN_CLOSED_MEM_INSUFFICIENT = C.XCB_CONN_CLOSED_MEM_INSUFFICIENT
-XCB_CONN_CLOSED_REQ_LEN_EXCEED = C.XCB_CONN_CLOSED_REQ_LEN_EXCEED
-XCB_CONN_CLOSED_PARSE_ERR = C.XCB_CONN_CLOSED_PARSE_ERR
-# XCB_CONN_CLOSED_INVALID_SCREEN = C.XCB_CONN_CLOSED_INVALID_SCREEN
-# XCB_CONN_CLOSED_FDPASSING_FAILED = C.XCB_CONN_CLOSED_FDPASSING_FAILED
+XCB_CONN_ERROR = lib.XCB_CONN_ERROR
+XCB_CONN_CLOSED_EXT_NOTSUPPORTED = lib.XCB_CONN_CLOSED_EXT_NOTSUPPORTED
+XCB_CONN_CLOSED_MEM_INSUFFICIENT = lib.XCB_CONN_CLOSED_MEM_INSUFFICIENT
+XCB_CONN_CLOSED_REQ_LEN_EXCEED = lib.XCB_CONN_CLOSED_REQ_LEN_EXCEED
+XCB_CONN_CLOSED_PARSE_ERR = lib.XCB_CONN_CLOSED_PARSE_ERR
+# XCB_CONN_CLOSED_INVALID_SCREEN = lib.XCB_CONN_CLOSED_INVALID_SCREEN
+# XCB_CONN_CLOSED_FDPASSING_FAILED = lib.XCB_CONN_CLOSED_FDPASSING_FAILED
 
 cffi_explicit_lifetimes = weakref.WeakKeyDictionary()
 
@@ -151,23 +156,23 @@ class XcffibException(Exception):
 
 class ConnectionException(XcffibException):
     REASONS = {
-        C.XCB_CONN_ERROR: (
+        lib.XCB_CONN_ERROR: (
             'xcb connection errors because of socket, '
             'pipe and other stream errors.'),
-        C.XCB_CONN_CLOSED_EXT_NOTSUPPORTED: (
+        lib.XCB_CONN_CLOSED_EXT_NOTSUPPORTED: (
             'xcb connection shutdown because extension not supported'),
-        C.XCB_CONN_CLOSED_MEM_INSUFFICIENT: (
+        lib.XCB_CONN_CLOSED_MEM_INSUFFICIENT: (
             'malloc(), calloc() and realloc() error upon failure, '
             'for eg ENOMEM'),
-        C.XCB_CONN_CLOSED_REQ_LEN_EXCEED: (
+        lib.XCB_CONN_CLOSED_REQ_LEN_EXCEED: (
             'Connection closed, exceeding request length that server '
             'accepts.'),
-        C.XCB_CONN_CLOSED_PARSE_ERR: (
+        lib.XCB_CONN_CLOSED_PARSE_ERR: (
             'Connection closed, error during parsing display string.'),
-        #        C.XCB_CONN_CLOSED_INVALID_SCREEN: (
+        #        lib.XCB_CONN_CLOSED_INVALID_SCREEN: (
         #            'Connection closed because the server does not have a screen '
         #            'matching the display.'),
-        #        C.XCB_CONN_CLOSED_FDPASSING_FAILED: (
+        #        lib.XCB_CONN_CLOSED_FDPASSING_FAILED: (
         #            'Connection closed because some FD passing operation failed'),
     }
 
@@ -350,7 +355,7 @@ class Extension(object):
         xcb_parts[3].iov_base = ffi.NULL
         xcb_parts[3].iov_len = -len(data) & 3  # is this really necessary?
 
-        flags = C.XCB_REQUEST_CHECKED if is_checked else 0
+        flags = lib.XCB_REQUEST_CHECKED if is_checked else 0
 
         seq = self.conn.send_request(flags, xcb_parts + 2, xcb_req)
 
@@ -471,11 +476,11 @@ class Connection(object):
         i = ffi.new("int *")
 
         if fd > 0:
-            self._conn = C.xcb_connect_to_fd(fd, c_auth)
+            self._conn = lib.xcb_connect_to_fd(fd, c_auth)
         elif c_auth != ffi.NULL:
-            self._conn = C.xcb_connect_to_display_with_auth_info(display, c_auth, i)
+            self._conn = lib.xcb_connect_to_display_with_auth_info(display, c_auth, i)
         else:
-            self._conn = C.xcb_connect(display, i)
+            self._conn = lib.xcb_connect(display, i)
         self.pref_screen = i[0]
         self.invalid()
         self._init_x()
@@ -497,7 +502,7 @@ class Connection(object):
             # We're explicitly not putting this as an argument to the next call
             # as a hack for lifetime management.
             c_ext = key.to_cffi()
-            reply = C.xcb_get_extension_data(self._conn, c_ext)
+            reply = lib.xcb_get_extension_data(self._conn, c_ext)
             self._event_offsets.add(reply.first_event, events)
             self._error_offsets.add(reply.first_error, errors)
 
@@ -507,7 +512,7 @@ class Connection(object):
     def invalid(self):
         if self._conn is None:
             raise XcffibException("Invalid connection.")
-        err = C.xcb_connection_has_error(self._conn)
+        err = lib.xcb_connection_has_error(self._conn)
         if err > 0:
             raise ConnectionException(err)
 
@@ -528,7 +533,7 @@ class Connection(object):
 
     @ensure_connected
     def get_setup(self):
-        self._setup = C.xcb_get_setup(self._conn)
+        self._setup = lib.xcb_get_setup(self._conn)
 
         # No idea where this 8 comes from either, similar complate to the
         # sizeof(xcb_generic_reply_t) below.
@@ -542,24 +547,24 @@ class Connection(object):
         Returns the xcb_screen_t for every screen
         useful for other bindings
         """
-        root_iter = C.xcb_setup_roots_iterator(self._setup)
+        root_iter = lib.xcb_setup_roots_iterator(self._setup)
 
         screens = [root_iter.data]
         for i in range(self._setup.roots_len - 1):
-            C.xcb_screen_next(ffi.addressof((root_iter)))
+            lib.xcb_screen_next(ffi.addressof((root_iter)))
             screens.append(root_iter.data)
         return screens
 
     @ensure_connected
     def wait_for_event(self):
-        e = C.xcb_wait_for_event(self._conn)
-        e = ffi.gc(e, C.free)
+        e = lib.xcb_wait_for_event(self._conn)
+        e = ffi.gc(e, lib.free)
         self.invalid()
         return self.hoist_event(e)
 
     @ensure_connected
     def poll_for_event(self):
-        e = C.xcb_poll_for_event(self._conn)
+        e = lib.xcb_poll_for_event(self._conn)
         self.invalid()
         if e != ffi.NULL:
             return self.hoist_event(e)
@@ -567,31 +572,31 @@ class Connection(object):
             return None
 
     def has_error(self):
-        return C.xcb_connection_has_error(self._conn)
+        return lib.xcb_connection_has_error(self._conn)
 
     @ensure_connected
     def get_file_descriptor(self):
-        return C.xcb_get_file_descriptor(self._conn)
+        return lib.xcb_get_file_descriptor(self._conn)
 
     @ensure_connected
     def get_maximum_request_length(self):
-        return C.xcb_get_maximum_request_length(self._conn)
+        return lib.xcb_get_maximum_request_length(self._conn)
 
     @ensure_connected
     def prefetch_maximum_request_length(self):
-        return C.xcb_prefetch_maximum_request_length(self._conn)
+        return lib.xcb_prefetch_maximum_request_length(self._conn)
 
     @ensure_connected
     def flush(self):
-        return C.xcb_flush(self._conn)
+        return lib.xcb_flush(self._conn)
 
     @ensure_connected
     def generate_id(self):
-        return C.xcb_generate_id(self._conn)
+        return lib.xcb_generate_id(self._conn)
 
     def disconnect(self):
         self.invalid()
-        return C.xcb_disconnect(self._conn)
+        return lib.xcb_disconnect(self._conn)
 
     def _process_error(self, c_error):
         self.invalid()
@@ -603,14 +608,14 @@ class Connection(object):
     @ensure_connected
     def wait_for_reply(self, sequence):
         error_p = ffi.new("xcb_generic_error_t **")
-        data = C.xcb_wait_for_reply(self._conn, sequence, error_p)
-        data = ffi.gc(data, C.free)
+        data = lib.xcb_wait_for_reply(self._conn, sequence, error_p)
+        data = ffi.gc(data, lib.free)
 
         try:
             self._process_error(error_p[0])
         finally:
             if error_p[0] != ffi.NULL:
-                C.free(error_p[0])
+                lib.free(error_p[0])
 
         if data == ffi.NULL:
             # No data and no error => bad sequence number
@@ -626,7 +631,7 @@ class Connection(object):
         cookie = ffi.new("xcb_void_cookie_t [1]")
         cookie[0].sequence = sequence
 
-        err = C.xcb_request_check(self._conn, cookie[0])
+        err = lib.xcb_request_check(self._conn, cookie[0])
         self._process_error(err)
 
     def hoist_event(self, e):
@@ -645,7 +650,7 @@ class Connection(object):
 
     @ensure_connected
     def send_request(self, flags, xcb_parts, xcb_req):
-        return C.xcb_send_request(self._conn, flags, xcb_parts, xcb_req)
+        return lib.xcb_send_request(self._conn, flags, xcb_parts, xcb_req)
 
 
 # More backwards compatibility
@@ -739,7 +744,7 @@ def pack_list(from_, pack_type):
 
 
 def wrap(ptr):
-    c_conn = C.wrap(ptr)
+    c_conn = lib.wrap(ptr)
     conn = Connection.__new__(Connection)
     conn._conn = c_conn
     conn._init_x()

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -13,43 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import binascii
-import sys
-import threading
-
 from cffi import FFI
-from cffi.verifier import Verifier
-
-
-# This is taken from https://caremad.io/2014/11/distributing-a-cffi-project/,
-# which gives examples from cryptography
-def _create_modulename(cdef_sources, source, sys_version):
-    """
-    This is the same as CFFI's create modulename except we don't include the
-    CFFI version.
-    """
-    key = '\x00'.join([sys_version[:3], source, cdef_sources])
-    key = key.encode('utf-8')
-    k1 = hex(binascii.crc32(key[0::2]) & 0xffffffff)
-    k1 = k1.lstrip('0x').rstrip('L')
-    k2 = hex(binascii.crc32(key[1::2]) & 0xffffffff)
-    k2 = k2.lstrip('0').rstrip('L')
-    return '_xcffib_cffi_{0}{1}'.format(k1, k2)
-
-
-class LazyCFFILibrary(object):
-    def __init__(self, ffi):
-        self._ffi = ffi
-        self._lib = None
-        self._lock = threading.Lock()
-
-    def __getattr__(self, name):
-        if self._lib is None:
-            with self._lock:
-                if self._lib is None:
-                    self._lib = self._ffi.verifier.load_library()
-
-        return getattr(self._lib, name)
 
 
 CONSTANTS = [
@@ -293,15 +257,8 @@ xcb_connection_t *wrap(long ptr) {
 
 
 ffi = FFI()
+ffi.set_source("xcffib._ffi", SOURCE, libraries=['xcb'])
 ffi.cdef(CDEF)
-ffi.verifier = Verifier(
-    ffi,
-    SOURCE,
-    libraries=['xcb'],
-    modulename=_create_modulename(CDEF, SOURCE, sys.version)
-)
-
-C = LazyCFFILibrary(ffi)
 
 
 def visualtype_to_c_struct(vt):
@@ -317,3 +274,7 @@ def visualtype_to_c_struct(vt):
     s.blue_mask = vt.blue_mask
 
     return s
+
+
+if __name__ == "__main__":
+    ffi.compile()

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -257,7 +257,8 @@ xcb_connection_t *wrap(long ptr) {
 
 
 ffi = FFI()
-ffi.set_source("xcffib._ffi", SOURCE, libraries=['xcb'])
+if hasattr(ffi, 'set_source'):  # PyPy < 2.6 compatibility hack
+    ffi.set_source("xcffib._ffi", SOURCE, libraries=['xcb'])
 ffi.cdef(CDEF)
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,43 +16,35 @@
 
 import os
 import sys
-import subprocess
 
-from setuptools import setup, find_packages
+from setuptools import setup
 from distutils.command.build import build
 from distutils.command.install import install
 
-# Stolen from http://github.com/xattr/xattr, which is also MIT licensed.
-class cffi_build(build):
-    """This is a shameful hack to ensure that cffi is present when
-    we specify ext_modules. We can't do this eagerly because
-    setup_requires hasn't run yet.
+
+class binding_build(build):
+    """This is a check to ensure that the bindings have been generated, and
+    print a helpful message if they have not been generated yet.  We only need
+    to check this when we are actually building or installing.
     """
     def finalize_options(self):
         if not os.path.exists('./xcffib'):
             print("It looks like you need to generate the binding.")
             print("please run 'make xcffib' or 'make check'.")
             sys.exit(1)
-
-        import xcffib
-
-        self.distribution.ext_modules = [xcffib.ffi.verifier.get_extension()]
         build.finalize_options(self)
 
-class cffi_install(install):
+
+class binding_install(install):
     def finalize_options(self):
         if not os.path.exists('./xcffib'):
             print("It looks like you need to generate the binding.")
             print("please run 'make xcffib' or 'make check'.")
             sys.exit(1)
-
-        import xcffib
-
-        self.distribution.ext_modules = [xcffib.ffi.verifier.get_extension()]
         install.finalize_options(self)
 
 version = "0.2.2"
-dependencies = ['six', 'cffi>=0.8.2']
+dependencies = ['six', 'cffi>=1.0.0']
 
 setup(
     name="xcffib",
@@ -66,9 +58,10 @@ setup(
     install_requires=dependencies,
     setup_requires=dependencies,
     packages=['xcffib'],
+    cffi_modules=["xcffib/ffi_build.py:ffi"],
     zip_safe=False,
     cmdclass={
-        'build': cffi_build,
-        'install': cffi_install
+        'build': binding_build,
+        'install': binding_install
     },
 )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,15 +16,15 @@
 import os
 import six
 import xcffib
-from xcffib.ffi import ffi, C
 import xcffib.xproto
+
+from xcffib import ffi
 from xcffib.testing import XvfbTest
 from .testing import XcffibTest
 
 from nose.tools import raises
 
 import struct
-import subprocess
 
 class TestConnection(XcffibTest):
 

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import xcffib
-from xcffib.ffi import ffi, C
 from xcffib.testing import XvfbTest
 from xcffib.xproto import EventMask
+
 
 class XcffibTest(XvfbTest):
     """ A home for common functions needed for xcffib testing. """
@@ -56,9 +56,10 @@ class XcffibTest(XvfbTest):
         self.xproto.ChangeWindowAttributes(
             self.default_screen.root,
             xcffib.xproto.CW.EventMask,
-            [ EventMask.SubstructureNotify |
-              EventMask.StructureNotify |
-              EventMask.SubstructureRedirect
+            [
+                EventMask.SubstructureNotify |
+                EventMask.StructureNotify |
+                EventMask.SubstructureRedirect
             ]
         )
 


### PR DESCRIPTION
Note that this breaks PyPy < 2.6 (current release is 2.5.1), so I have allowed failure on those tests. The cffi docs have a section on making cffi 1.0 and 0.9 compatible code ([here](http://cffi.readthedocs.org/en/latest/cdef.html#upgrading-from-cffi-0-9-to-cffi-1-0)) until 2.6 is released, if we want to maintain compatibility, I can implement something like that.

With this, `make xcffib` will also build the cffi module, which can also be done manually by running `setup.py build_ext --inplace`, or maybe running `python xcffib/ffi_build.py` (?).