### PR TITLE
Use ABI-based cffi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ xcffib: $(GEN) module/*.py
 	$(GEN) --input $(XCBDIR) --output ./xcffib
 	cp ./module/*py ./xcffib/
 	sed -i "s/__xcb_proto_version__ = .*/__xcb_proto_version__ = \"${XCBVER}\"/" xcffib/__init__.py
-	python setup.py build_ext --inplace
+	python xcffib/ffi_build.py
 
 .PHONY: xcffib-fmt
 xcffib-fmt: $(GEN) module/*.py

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -21,12 +21,11 @@ import struct
 import weakref
 
 try:
-    from xcffib._ffi import ffi, lib
+    from xcffib._ffi import ffi
 except ImportError:
-    from xcffib.ffi_build import ffi, SOURCE
-    lib = ffi.verify(SOURCE, libraries=['xcb'], ext_package='xcffib')
-# We're just re-exporting visualtype_to_c_struct, hence the noqa.
-from xcffib.ffi_build import visualtype_to_c_struct  # noqa
+    from xcffib.ffi_build import ffi
+
+lib = ffi.dlopen('libxcb.so')
 
 __xcb_proto_version__ = 'placeholder'
 
@@ -57,6 +56,22 @@ cffi_explicit_lifetimes = weakref.WeakKeyDictionary()
 
 def type_pad(t, i):
     return -i & (3 if t > 4 else t - 1)
+
+
+def visualtype_to_c_struct(vt):
+    # let ffi be a kwarg so cairocffi can pass in its ffi
+    # cfficairo needs an xcb_visualtype_t
+    s = ffi.new("struct xcb_visualtype_t *")
+
+    s.visual_id = vt.visual_id
+    s._class = vt._class
+    s.bits_per_rgb_value = vt.bits_per_rgb_value
+    s.colormap_entries = vt.colormap_entries
+    s.red_mask = vt.red_mask
+    s.green_mask = vt.green_mask
+    s.blue_mask = vt.blue_mask
+
+    return s
 
 
 class Unpacker(object):

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -744,9 +744,14 @@ def pack_list(from_, pack_type):
 
 
 def wrap(ptr):
-    c_conn = lib.wrap(ptr)
+    c_conn = ffi.cast('xcb_connection_t *', ptr)
     conn = Connection.__new__(Connection)
     conn._conn = c_conn
     conn._init_x()
     conn.invalid()
+
+    # ptr owns the memory for c_conn, even after the cast
+    # we should keep it alive
+    cffi_explicit_lifetimes[conn] = ptr
+
     return conn

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -239,8 +239,6 @@ CDEF += """
     unsigned int xcb_send_request(xcb_connection_t *c, int flags, struct iovec *vector, const xcb_protocol_request_t *request);
     void *xcb_wait_for_reply(xcb_connection_t *c, unsigned int request, xcb_generic_error_t **e);
     int xcb_poll_for_reply(xcb_connection_t *c, unsigned int request, void **reply, xcb_generic_error_t **error);
-
-    xcb_connection_t *wrap(long ptr);
 """
 
 
@@ -249,10 +247,6 @@ SOURCE = """
 #include <xcb/xcb.h>
 #include <xcb/xcbext.h>
 #include <xcb/render.h>
-
-xcb_connection_t *wrap(long ptr) {
-    return (xcb_connection_t *) ptr;
-}
 """
 
 

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -17,29 +17,29 @@ from cffi import FFI
 
 
 CONSTANTS = [
-    "X_PROTOCOL",
-    "X_PROTOCOL_REVISION",
-    "X_TCP_PORT",
+    ("X_PROTOCOL", 11),
+    ("X_PROTOCOL_REVISION", 0),
+    ("X_TCP_PORT", 6000),
 
-    "XCB_NONE",
-    "XCB_COPY_FROM_PARENT",
-    "XCB_CURRENT_TIME",
-    "XCB_NO_SYMBOL",
+    ("XCB_NONE", 0),
+    ("XCB_COPY_FROM_PARENT", 0),
+    ("XCB_CURRENT_TIME", 0),
+    ("XCB_NO_SYMBOL", 0),
 
-    "XCB_CONN_ERROR",
-    "XCB_CONN_CLOSED_EXT_NOTSUPPORTED",
-    "XCB_CONN_CLOSED_MEM_INSUFFICIENT",
-    "XCB_CONN_CLOSED_REQ_LEN_EXCEED",
-    "XCB_CONN_CLOSED_PARSE_ERR",
-    #    "XCB_CONN_CLOSED_INVALID_SCREEN",
-    #    "XCB_CONN_CLOSED_FDPASSING_FAILED",
+    ("XCB_CONN_ERROR", 1),
+    ("XCB_CONN_CLOSED_EXT_NOTSUPPORTED", 2),
+    ("XCB_CONN_CLOSED_MEM_INSUFFICIENT", 3),
+    ("XCB_CONN_CLOSED_REQ_LEN_EXCEED", 4),
+    ("XCB_CONN_CLOSED_PARSE_ERR", 5),
+    ("XCB_CONN_CLOSED_INVALID_SCREEN", 6),
+    ("XCB_CONN_CLOSED_FDPASSING_FAILED", 7),
 
-    "XCB_REQUEST_CHECKED",
+    ("XCB_REQUEST_CHECKED", 1 << 0)
 ]
 
 
 # constants
-CDEF = '\n'.join("#define %s ..." % c for c in CONSTANTS)
+CDEF = '\n'.join("#define %s %d" % (c, v) for c, v in CONSTANTS)
 
 # types
 CDEF += """
@@ -242,34 +242,14 @@ CDEF += """
 """
 
 
-SOURCE = """
-#include <stdlib.h>
-#include <xcb/xcb.h>
-#include <xcb/xcbext.h>
-#include <xcb/render.h>
-"""
-
-
 ffi = FFI()
 if hasattr(ffi, 'set_source'):  # PyPy < 2.6 compatibility hack
-    ffi.set_source("xcffib._ffi", SOURCE, libraries=['xcb'])
+    ffi.set_source("xcffib._ffi", None, libraries=['xcb'])
+    do_compile = True
+else:
+    do_compile = False
 ffi.cdef(CDEF)
 
 
-def visualtype_to_c_struct(vt):
-    # cfficairo needs an xcb_visualtype_t
-    s = ffi.new("xcb_visualtype_t *")
-
-    s.visual_id = vt.visual_id
-    s._class = vt._class
-    s.bits_per_rgb_value = vt.bits_per_rgb_value
-    s.colormap_entries = vt.colormap_entries
-    s.red_mask = vt.red_mask
-    s.green_mask = vt.green_mask
-    s.blue_mask = vt.blue_mask
-
-    return s
-
-
-if __name__ == "__main__":
+if __name__ == "__main__" and do_compile:
     ffi.compile()

--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,19 @@ setup(
         'build': binding_build,
         'install': binding_install
     },
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Libraries'
+    ],
     **cffi_args
 )


### PR DESCRIPTION
Link against cffi libraries using dlopen rather than compiling against the xcb library.

While this may complicate things, we need to maintain the values of defines and it may not be immediately apparent on install that there are problems with the libxcb install, this allows us to build xcb support into carocffi using the new cffi-1.0 features, since cairocffi links against ABI and has no intention of changing.

The wrap declaration is removed in favor of doing a `ffi.cast()` call. I'm not totally sure how this is used, but I linked the pointer lifetime to the returned Connection object.