### PR TITLE
Fix pip install for certain versions of pip/setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ import os
 import sys
 
 from setuptools import setup
+from setuptools.command.install import install
 from distutils.command.build import build
-from distutils.command.install import install
 
 
 class binding_build(build):


### PR DESCRIPTION
Import the `install` command from setuptools rather than distutils, for some pip/setuptools/distutils versions, this would break installs with `error: option --single-version-externally-managed not recognized`