### PR TITLE
Exclude xcffib/_ffi.py from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+exclude xcffib/_ffi.py


### PR DESCRIPTION
xcffib/_ffi.py should not ship with sdist'd packages, as it will be built by the cffi setuptools extension on install if needed (for cffi >=1), but if it has been previously built, it will be included in the sdist package.  Explicitly exclude it in this case.

This is really a problem for pre-cffi 1.0 PyPy versions [1] which shouldn't have this file, and where having the file screws up the `try`/`catch ImportError` block.

[1] https://travis-ci.org/flacjacket/cairocffi/jobs/65103781