### PR TITLE
Use Travis containers explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
       - xvfb
 
 install:
+  - ls $HOME/.ghc/*
   - cabal update
   - cabal install --only-dependencies --enable-tests
   - cabal configure --enable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,29 @@ python:
   - pypy
   - pypy3
 
-before_install:
-  - sudo apt-get update
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cabal/lib
+    - $HOME/.ghc
+
+addons:
+  apt:
+    packages:
+      - xcb-proto
+      - ghc
+      - cabal-install
+      - happy
+      - alex
+      - x11-apps
+      - xvfb
 
 install:
-  - sudo apt-get install ghc cabal-install git xcb-proto happy alex xvfb libxcb1-dev x11-apps parallel
   - cabal update
   - cabal install --only-dependencies --enable-tests
   - cabal configure --enable-tests
   - pip install -r requirements.txt
 
 script: "make -j3 check"
+
+sudo: false


### PR DESCRIPTION
You can just cherrypick the first commit, the other one is just to see if caching works. It looks like the pip cache is saved, but Haskell is re-building everything, which is annoying, do you know why it doesn't take the stuff in `~/.cabal`? Even without cabal caching, the builds drop from ~8 min to ~6 min from having more resources and the tests spin up much much faster.

```
Turn on using Travis Docker containers, giving faster start times more
allocated resources (particularly nice for building Haskell stuff).
Also, cache pip and cabal stuff, this should make test run much faster
by not having to re-build Haskell dependencies.
```