### PR TITLE
Support `xcb_discard_reply`

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -329,6 +329,9 @@ class Cookie(object):
             "Request is not void and checked")
         self.conn.request_check(self.sequence)
 
+    def discard_reply(self):
+        return self.conn.discard_reply(self.sequence)
+
 
 class VoidCookie(Cookie):
 

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -680,6 +680,10 @@ class Connection(object):
     def send_request(self, flags, xcb_parts, xcb_req):
         return lib.xcb_send_request(self._conn, flags, xcb_parts, xcb_req)
 
+    @ensure_connected
+    def discard_reply(self, sequence):
+        return lib.xcb_discard_reply(self._conn, sequence)
+
 
 # More backwards compatibility
 connect = Connection

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -239,6 +239,7 @@ CDEF += """
     unsigned int xcb_send_request(xcb_connection_t *c, int flags, struct iovec *vector, const xcb_protocol_request_t *request);
     void *xcb_wait_for_reply(xcb_connection_t *c, unsigned int request, xcb_generic_error_t **e);
     int xcb_poll_for_reply(xcb_connection_t *c, unsigned int request, void **reply, xcb_generic_error_t **error);
+    void xcb_discard_reply(xcb_connection_t *c, unsigned int sequence);
 """
 
 


### PR DESCRIPTION
I can't create the unittest; I'm not sure how to verify that a reply has been discarded (I think sequence numbers wrap-around).

Closes #72 .