### PR TITLE
[pack_list]+[pyunify]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ debian/tmp
 debian/python-xcffib*
 debian/python3-xcffib*
 .pybuild
+.cabal-sandbox/
+cabal.sandbox.config

--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -91,7 +91,7 @@ xform = map buildPython . dependencyOrder
     processXHeader :: XHeader
                    -> State TypeInfoMap (String, Suite ())
     processXHeader header = do
-      let imports = [mkImport "xcffib", mkImport "struct", mkImport "six"]
+      let imports = [mkImport "xcffib", mkImport "struct", mkImport "io"]
           version = mkVersion header
           key = maybeToList $ mkKey header
           globals = [mkDict "_events", mkDict "_errors"]
@@ -382,7 +382,7 @@ structElemToPyPack _ m accessor (ValueParam typ mask _ list) =
       "ValueParams other than CARD{16,32} not allowed.")
 
 buf :: Suite ()
-buf = [mkAssign "buf" (mkCall "six.BytesIO" noArgs)]
+buf = [mkAssign "buf" (mkCall "io.BytesIO" noArgs)]
 
 mkPackStmts :: String
             -> String

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,8 +760,15 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
-    elif isinstance(pack_type, six.class_types) and issubclass(pack_type, Protobj) and hasattr(pack_type, "synthetic"):
-        return b"".join(pack_type.synthetic(*f).pack() for f in from_)
+    elif    (   isinstance(pack_type, six.class_types)
+            and issubclass(pack_type, Protobj)
+            and hasattr(pack_type, "synthetic")
+            and hasattr(pack_type, "pack")
+            ):
+        return b"".join(
+            f.pack() if isinstance(f, pack_type) else pack_type.synthetic(*f).pack()
+            for f in from_
+        )
     else:
         buf = six.BytesIO()
         for item in from_:

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -766,18 +766,19 @@ def pack_list(from_, pack_type):
             and hasattr(pack_type, "pack")
             ):
         return b"".join(
-            f.pack() if isinstance(f, pack_type) else pack_type.synthetic(*f).pack()
+                f.pack()
+            if isinstance(f, pack_type) else
+                pack_type.synthetic(*f).pack()
             for f in from_
         )
     else:
-        buf = six.BytesIO()
-        for item in from_:
-            # If we can't pack it, you'd better have packed it yourself...
-            if isinstance(item, Protobj) and hasattr(item, "pack"):
-                buf.write(item.pack())
-            else:
-                buf.write(item)
-        return buf.getvalue()
+        # If we can't pack it, you'd better have packed it yourself...
+        return b"".join(
+                f.pack()
+            if isinstance(item, Protobj) and hasattr(item, "pack") else
+                f
+            for f in from_
+        )
 
 
 def wrap(ptr):

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,13 +760,13 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
+    elif hasattr(pack_type, "synthetic"):
+        return pack_type.synthetic(*from_).pack()
     else:
         buf = six.BytesIO()
         for item in from_:
-            # If we can't pack it, you'd better have packed it yourself. But
-            # let's not confuse things which aren't our Probobjs for packable
-            # things.
-            if isinstance(item, Protobj) and hasattr(item, "pack"):
+            # If we can't pack it, you'd better have packed it yourself...
+            if isinstance(item, Struct):
                 buf.write(item.pack())
             else:
                 buf.write(item)

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -20,6 +20,9 @@ import platform
 import six
 import struct
 import weakref
+import codecs
+import locale
+import io
 
 try:
     from xcffib._ffi import ffi
@@ -437,21 +440,44 @@ class List(Protobj):
     def __delitem__(self, key):
         del self.list[key]
 
+    def buf(self):
+        return b"".join(self)
+
+    def decode(self, encoding="utf-8", errors="strict"):
+        # codecs.decode provides more flexibility
+        return codecs.decode(self.buf(), encoding, errors)
+
+    def to_bytes(self):
+        """wrapper around `self.buf`, to mirror `self.to_string`"""
+        return self.buf()
+
     def to_string(self):
-        """ A helper for converting a List of chars to a native string. Dies if
-        the list contents are not something that could be reasonably converted
-        to a string. """
-        return ''.join(chr(six.byte2int(i)) for i in self)
+        # The old approach:
+        #   return ''.join(chr(six.byte2int(i)) for i in self)
+        # Which was broken under python 3, and should have been:
+        #   return ''.join(chr(i) for i in six.iterbytes(self))
+        # Is completely crazy. Under python 3, it converts `bytes` to `str`
+        # (unicode object), equivalent to:
+        #   return self.decode("unicode-escape")
+        # Under python 2, it has no effect, equivalent to:
+        #   return self.buf()
+        # Anyway, it doesn't make sense to return a bytes object in python 2
+        # but a unicode object in python 3, so now:
+        """A helper for decoding a List of bytes to the platform's default
+        encoding. Bytes outside the codec's range are replaced with U+FFFD
+        REPLACEMENT CHARACTER (errors="replace")."""
+        # On python 2, comparisons between `unicode` and `str` succeed as long
+        # as the `unicode` code points are all ASCII - so unit tests should
+        # continue working.
+        return self.decode(locale.getpreferredencoding(False), errors="replace")
 
     def to_utf8(self):
-        return six.b('').join(self).decode('utf-8')
+        return self.decode("utf-8")
 
     def to_atoms(self):
         """ A helper for converting a List of chars to an array of atoms """
-        return struct.unpack("=" + "I" * (len(self) // 4), b''.join(self))
-
-    def buf(self):
-        return b''.join(self.list)
+        assert len(self) % 4 == 0
+        return list(struct.unpack("=" + "I" * (len(self) // 4), b''.join(self)))
 
     @classmethod
     def synthetic(cls, list=None):
@@ -486,7 +512,7 @@ class Connection(object):
     xpyb. """
     def __init__(self, display=None, fd=-1, auth=None):
         if auth is not None:
-            [name, data] = auth.split(six.b(':'))
+            [name, data] = auth.split(b':')
 
             c_auth = ffi.new("xcb_auth_info_t *")
             c_auth.name = ffi.new('char[]', name)
@@ -746,25 +772,23 @@ def pack_list(from_, pack_type):
             # PY3 is "helpful" in that when you do tuple(b'foo') you get
             # (102, 111, 111) instead of something more reasonable like
             # (b'f', b'o', b'o'), so we rebuild from_ as a tuple of bytes
-            from_ = [six.int2byte(b) for b in six.iterbytes(from_)]
+            from_ = list(struct.unpack("c" * len(from_), from_))
         elif isinstance(from_, six.string_types):
             # Catch Python 3 strings and Python 2 unicode strings, both of
             # which we encode to bytes as utf-8
             # Here we create the tuple of bytes from the encoded string
-            from_ = [six.int2byte(b) for b in bytearray(from_, 'utf-8')]
+            from_ = from_.encode("utf-8")
+            from_ = list(struct.unpack("c" * len(from_), from_))
         elif isinstance(from_[0], six.integer_types):
             # Pack from_ as char array, where from_ may be an array of ints
             # possibly greater than 256
-            def to_bytes(v):
-                for _ in range(4):
-                    v, r = divmod(v, 256)
-                    yield r
-            from_ = [six.int2byte(b) for i in from_ for b in to_bytes(i)]
+            from_ = struct.pack("<" + "I" * len(from_), *from_)
+            from_ = struct.unpack("c" * len(from_), from_)
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
     else:
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         synthesize = (isinstance(pack_type, six.class_types) and
                       issubclass(pack_type, Struct) and
                       hasattr(pack_type, "synthetic") and
@@ -775,21 +799,9 @@ def pack_list(from_, pack_type):
             elif synthesize:
                 packed = pack_type.synthetic(*item).pack()
             else:
-                # If we can't pack it, you'd better have packed it yourself...
                 packed = item
-            # * On python2, six.BytesIO wraps StringIO.StringIO - even with
-            #   versions of python >= 2.6, which provide the `io` module (with
-            #   io.BytesIO). Method write() accepts any object, and writes its
-            #   __str__ representation.
-            # * On python3, six.BytesIO wraps io.BytesIO. Method write()
-            #   requires objects supporting the buffer protocol/interface, or
-            #   throws TypeError.
-            # six.BytesIO provides compatibility with python < 2.6 - otherwise
-            # we would just use io.BytesIO. To catch otherwise hard-to-detect
-            # errors on python 2, however, ensure that we are actually writing
-            # a `bytes` object. Since versions of python 2 <= 2.5 do not
-            # support the `bytes` alias, use `six.binary_type` instead.
-            assert isinstance(packed, six.binary_type)
+            # Raises `TypeError` if `packed` does not support the buffer
+            # protocol/interface. On python2, this includes the `str` type.
             buf.write(packed)
         return buf.getvalue()
 

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -767,7 +767,7 @@ def pack_list(from_, pack_type):
             ):
         return b"".join(
                 f.pack()
-            if isinstance(f, pack_type) else
+            if isinstance(item, Protobj) and hasattr(item, "pack") else
                 pack_type.synthetic(*f).pack()
             for f in from_
         )

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,22 +760,20 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
-    elif    (   isinstance(pack_type, six.class_types)
+    else:
+        synthesize = \
+            (   isinstance(pack_type, six.class_types)
             and issubclass(pack_type, Protobj)
             and hasattr(pack_type, "synthetic")
             and hasattr(pack_type, "pack")
-            ):
+            )
         return b"".join(
                 f.pack()
-            if isinstance(item, Protobj) and hasattr(item, "pack") else
+            if isinstance(f, Protobj) and hasattr(f, "pack") else
                 pack_type.synthetic(*f).pack()
-            for f in from_
-        )
-    else:
-        # If we can't pack it, you'd better have packed it yourself...
-        return b"".join(
-                f.pack()
-            if isinstance(item, Protobj) and hasattr(item, "pack") else
+            if synthesize else:
+                # If we can't pack it, you'd better have packed it yourself...
+                # Otherwise, TypeError
                 f
             for f in from_
         )

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -771,7 +771,7 @@ def pack_list(from_, pack_type):
                 f.pack()
             if isinstance(f, Protobj) and hasattr(f, "pack") else
                 pack_type.synthetic(*f).pack()
-            if synthesize else:
+            if synthesize else
                 # If we can't pack it, you'd better have packed it yourself...
                 # Otherwise, TypeError
                 f

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,7 +760,7 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
-    elif isinstance(item, Protobj) and hasattr(pack_type, "synthetic"):
+    elif isinstance(pack_type, Protobj) and hasattr(pack_type, "synthetic"):
         return b"".join(pack_type.synthetic(*f).pack() for f in from_)
     else:
         buf = six.BytesIO()

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -651,7 +651,10 @@ class Connection(object):
 
         reply = ffi.cast("xcb_generic_reply_t *", data)
 
-        # why is this 32 and not sizeof(xcb_generic_reply_t) == 8?
+        # this is 32 and not `sizeof(xcb_generic_reply_t) == 8` because,
+        # according to the X11 protocol specs: "Every reply consists of 32 bytes
+        # followed by zero or more additional bytes of data, as specified in the
+        # length field."
         return CffiUnpacker(data, known_max=32 + reply.length * 4)
 
     @ensure_connected

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,13 +760,13 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
-    elif hasattr(pack_type, "synthetic"):
-        return pack_type.synthetic(*from_).pack()
+    elif isinstance(item, Protobj) and hasattr(pack_type, "synthetic"):
+        return b"".join(pack_type.synthetic(f).pack() for f in from_)
     else:
         buf = six.BytesIO()
         for item in from_:
             # If we can't pack it, you'd better have packed it yourself...
-            if isinstance(item, Struct):
+            if isinstance(item, Protobj) and hasattr(item, "pack"):
                 buf.write(item.pack())
             else:
                 buf.write(item)

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -760,7 +760,7 @@ def pack_list(from_, pack_type):
 
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
-    elif isinstance(pack_type, Protobj) and hasattr(pack_type, "synthetic"):
+    elif isinstance(pack_type, six.class_types) and issubclass(pack_type, Protobj) and hasattr(pack_type, "synthetic"):
         return b"".join(pack_type.synthetic(*f).pack() for f in from_)
     else:
         buf = six.BytesIO()

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -761,7 +761,7 @@ def pack_list(from_, pack_type):
     if isinstance(pack_type, six.string_types):
         return struct.pack("=" + pack_type * len(from_), *from_)
     elif isinstance(item, Protobj) and hasattr(pack_type, "synthetic"):
-        return b"".join(pack_type.synthetic(f).pack() for f in from_)
+        return b"".join(pack_type.synthetic(*f).pack() for f in from_)
     else:
         buf = six.BytesIO()
         for item in from_:

--- a/test/generator/enum.py
+++ b/test/generator/enum.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class DeviceUse:

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
 key = xcffib.ExtensionKey("ERROR")
@@ -15,7 +15,7 @@ class RequestError(xcffib.Error):
         self.bad_value, self.minor_opcode, self.major_opcode = unpacker.unpack("xx2xIHBx")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 1))
         buf.write(struct.pack("=x2xIHBx", self.bad_value, self.minor_opcode, self.major_opcode))
         return buf.getvalue()

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 1
 MINOR_VERSION = 4
 key = xcffib.ExtensionKey("EVENT")
@@ -15,7 +15,7 @@ class ScreenChangeNotifyEvent(xcffib.Event):
         self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight = unpacker.unpack("xB2xIIIIHHHHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 0))
         buf.write(struct.pack("=B2xIIIIHHHHHH", self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight))
         buf_len = len(buf.getvalue())

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class KeymapNotifyEvent(xcffib.Event):
@@ -13,7 +13,7 @@ class KeymapNotifyEvent(xcffib.Event):
         self.keys = xcffib.List(unpacker, "B", 31)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 11))
         buf.write(xcffib.pack_list(self.keys, "B"))
         buf_len = len(buf.getvalue())

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
@@ -15,7 +15,7 @@ class COLOR(xcffib.Struct):
         self.red, self.green, self.blue, self.alpha = unpacker.unpack("HHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=HHHH", self.red, self.green, self.blue, self.alpha))
         return buf.getvalue()
     fixed_size = 8
@@ -36,7 +36,7 @@ class RECTANGLE(xcffib.Struct):
         self.x, self.y, self.width, self.height = unpacker.unpack("hhHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=hhHH", self.x, self.y, self.width, self.height))
         return buf.getvalue()
     fixed_size = 8
@@ -50,7 +50,7 @@ class RECTANGLE(xcffib.Struct):
         return self
 class renderExtension(xcffib.Extension):
     def FillRectangles(self, op, dst, color, rects_len, rects, is_checked=False):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xB3xI", op, dst))
         buf.write(color.pack() if hasattr(color, "pack") else COLOR.synthetic(*color).pack())
         buf.write(xcffib.pack_list(rects, RECTANGLE))

--- a/test/generator/render_1.7.py
+++ b/test/generator/render_1.7.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")

--- a/test/generator/request.py
+++ b/test/generator/request.py
@@ -1,11 +1,11 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class requestExtension(xcffib.Extension):
     def CreateWindow(self, depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list, is_checked=False):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xBIIhhHHHHI", depth, wid, parent, x, y, width, height, border_width, _class, visual))
         buf.write(struct.pack("=I", value_mask))
         buf.write(xcffib.pack_list(value_list, "I"))

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class STR(xcffib.Struct):
@@ -13,7 +13,7 @@ class STR(xcffib.Struct):
         self.name = xcffib.List(unpacker, "c", self.name_len)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", self.name_len))
         buf.write(xcffib.pack_list(self.name, "c"))
         return buf.getvalue()
@@ -36,7 +36,7 @@ class ListExtensionsCookie(xcffib.Cookie):
     reply_type = ListExtensionsReply
 class request_replyExtension(xcffib.Extension):
     def ListExtensions(self, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2x"))
         return self.send_request(99, buf, ListExtensionsCookie, is_checked=is_checked)
 xcffib._add_ext(key, request_replyExtension, _events, _errors)

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class AxisInfo(xcffib.Struct):
@@ -12,7 +12,7 @@ class AxisInfo(xcffib.Struct):
         self.resolution, self.minimum, self.maximum = unpacker.unpack("Iii")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=Iii", self.resolution, self.minimum, self.maximum))
         return buf.getvalue()
     fixed_size = 12
@@ -33,7 +33,7 @@ class ValuatorInfo(xcffib.Struct):
         self.axes = xcffib.List(unpacker, AxisInfo, self.axes_len)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=BBBBI", self.class_id, self.len, self.axes_len, self.mode, self.motion_size))
         buf.write(xcffib.pack_list(self.axes, AxisInfo))
         return buf.getvalue()

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class CHARINFO(xcffib.Struct):
@@ -12,7 +12,7 @@ class CHARINFO(xcffib.Struct):
         self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes = unpacker.unpack("hhhhhH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=hhhhhH", self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes))
         return buf.getvalue()
     fixed_size = 12
@@ -35,7 +35,7 @@ class FONTPROP(xcffib.Struct):
         self.name, self.value = unpacker.unpack("II")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=II", self.name, self.value))
         return buf.getvalue()
     fixed_size = 8
@@ -66,7 +66,7 @@ class ListFontsWithInfoCookie(xcffib.Cookie):
     reply_type = ListFontsWithInfoReply
 class type_padExtension(xcffib.Extension):
     def ListFontsWithInfo(self, max_names, pattern_len, pattern, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xxHH", max_names, pattern_len))
         buf.write(xcffib.pack_list(pattern, "c"))
         return self.send_request(50, buf, ListFontsWithInfoCookie, is_checked=is_checked)

--- a/test/generator/union.py
+++ b/test/generator/union.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class ClientMessageData(xcffib.Union):
@@ -12,7 +12,7 @@ class ClientMessageData(xcffib.Union):
         self.data16 = xcffib.List(unpacker.copy(), "H", 10)
         self.data32 = xcffib.List(unpacker.copy(), "I", 5)
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(xcffib.pack_list(self.data8, "B"))
         return buf.getvalue()
 xcffib._add_ext(key, unionExtension, _events, _errors)

--- a/test/generator/xproto_1.7.py
+++ b/test/generator/xproto_1.7.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("XPROTO")

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -226,7 +226,7 @@ class TestConnection(XcffibTest):
 
         reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
 
-        assert reply.value.to_atoms() == (wm_delete_window,)
+        assert reply.value.to_atoms() == [wm_delete_window]
 
         wm_take_focus = self.intern("WM_TAKE_FOCUS")
 
@@ -236,7 +236,7 @@ class TestConnection(XcffibTest):
 
         reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
 
-        assert reply.value.to_atoms() == (wm_take_focus,)
+        assert reply.value.to_atoms() == [wm_take_focus]
 
     def test_GetAtomName(self):
         wm_protocols = "WM_PROTOCOLS"
@@ -270,10 +270,10 @@ class TestConnection(XcffibTest):
         c.disconnect()
 
     def test_auth_connect(self):
-        authname = six.b("MIT-MAGIC-COOKIE-1")
-        authdata = six.b("\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47")
+        authname = b"MIT-MAGIC-COOKIE-1"
+        authdata = b"\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47"
 
-        authstr = authname + six.b(':') + authdata
+        authstr = authname + b':' + authdata
 
         conn = xcffib.connect(display=os.environ['DISPLAY'], auth=authstr)
 

--- a/test/test_python_code.py
+++ b/test/test_python_code.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import xcffib
 import xcffib.xproto
 import struct
@@ -163,16 +162,16 @@ class TestPythonCode(XcffibTest):
         pack_list_test_synthetic(data_synthetic, StructTest)
 
     def test_pack_list_packed(self):
-        data_packed = [six.b(s) for s in ["one", "two", "three"]]
+        data_packed = [b"one", b"two", b"three"]
 
         def pack_list_test_packed(packed_list):
             packed_a = xcffib.pack_list(packed_list, None)
-            packed_b = six.b("").join(b for b in packed_list)
+            packed_b = b"".join(b for b in packed_list)
             assert packed_a == packed_b
 
         pack_list_test_packed(data_packed)
 
-    @raises(AssertionError)
+    @raises(TypeError)
     def test_pack_list_unpacked(self):
         data_unpacked = [object(), [1, 2, 3]]
         xcffib.pack_list(data_unpacked, None)


### PR DESCRIPTION
Merges my `pack_list` and `pyunify` branches. The `pack_list` branch is identical to the original pull request, #70. The `pyunify` branch unifies and simplifies python 2 and python 3 support as much as possible by removing most uses of the module `six`. Should address your concern:

> [Can this all be simplified if we drop support for 2.6? I just pushed a commit to do that now, because I think 2.6 is way past EOL anyway and nobody is using it.](https://github.com/tych0/xcffib/pull/74#issuecomment-222214244)

Technically, these changes should still be compatible with python 2.6 (mainly, `six` was used to provide python 2.5 compatibility).

Closed/reopened so I could switch branches. Also the python 3.2 build timed out during the `test.test_connection.TestConnection.test_external_ConfigureWindow` test.

Resolves #68.
