### PR TITLE
value_list is gone in latest xproto

### DIFF
--- a/test/testing.py
+++ b/test/testing.py
@@ -44,10 +44,6 @@ class XcffibTest(XvfbTest):
             xcffib.xproto.WindowClass.InputOutput,
             self.default_screen.root_visual,
             xcffib.xproto.CW.BackPixel | xcffib.xproto.CW.EventMask,
-            [
-                self.default_screen.black_pixel,
-                xcffib.xproto.EventMask.StructureNotify
-            ],
             is_checked=is_checked
         )
 
@@ -56,11 +52,6 @@ class XcffibTest(XvfbTest):
         self.xproto.ChangeWindowAttributes(
             self.default_screen.root,
             xcffib.xproto.CW.EventMask,
-            [
-                EventMask.SubstructureNotify |
-                EventMask.StructureNotify |
-                EventMask.SubstructureRedirect
-            ]
         )
 
         self.spawn(['xeyes'])


### PR DESCRIPTION
```
  File "/build/python-xcffib/src/xcffib/test/testing.py", line 51, in create_window
    is_checked=is_checked
TypeError: CreateWindow() got multiple values for argument 'is_checked'
```

The tests are still failing after the patch due to other errors, though.