### PR TITLE
ffi_build.py was run before the move to xcffib/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,7 @@ xcffib: $(GEN) module/*.py
 	$(GEN) --input $(XCBDIR) --output ./xcffib
 	cp ./module/*py ./xcffib/
 	sed -i "s/__xcb_proto_version__ = .*/__xcb_proto_version__ = \"${XCBVER}\"/" xcffib/__init__.py
-ifeq ($(TRAVIS),true)
-	python xcffib/ffi_build.py
-else
-	$(shell python xcffib/ffi_build.py > /dev/null 2>&1 || python3 xcffib/ffi_build.py)
-endif
+	@if [ "$(TRAVIS)" = true ]; then python xcffib/ffi_build.py; else python xcffib/ffi_build.py > /dev/null 2>&1 || python3 xcffib/ffi_build.py; fi
 
 .PHONY: xcffib-fmt
 xcffib-fmt: $(GEN) module/*.py


### PR DESCRIPTION
ifeq was evaluated when reading the Makefile, so ffi_build.py was run
before the actual file were moved to xcffib/ when invoked via `make xcffib`, so it always fails here.
Using shell if here would fix this.