### PR TITLE
Use more efficient unpack format

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -415,7 +415,7 @@ class List(Protobj):
         old = unpacker.offset
 
         if isinstance(typ, str):
-            self.list = list(unpacker.unpack(typ * count))
+            self.list = list(unpacker.unpack("%d%s" % (count, typ)))
         elif count is not None:
             for _ in range(count):
                 item = typ(unpacker)


### PR DESCRIPTION
unpacker.unpack() use struct.unpack_from internally, which cache
struct.Struct objects built for each format. Such object for large
formats is large. For example, 4MB format results in 128MB Struct
object, cached forever. While such large formats are rare, sometimes
they are needed (for example when retrieving large icons).

Solve this by more efficient format, using repeat count, instead of
expanding format manually. For the example above, it reduces Struct
object size to just 120B.

Closes #93

Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>