### PR TITLE
When unpacking, compute size without adjusting for alignment.

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -106,10 +106,11 @@ class Unpacker(object):
         self.offset += type_pad(size, self.offset)
 
     def unpack(self, fmt, increment=True):
+        fmt = "=" + fmt
         size = struct.calcsize(fmt)
         if size > self.size - self.offset:
             self._resize(size)
-        ret = struct.unpack_from("=" + fmt, self.buf, self.offset)
+        ret = struct.unpack_from(fmt, self.buf, self.offset)
 
         if increment:
             self.offset += size


### PR DESCRIPTION
`struct.calcsize()` gives different answers depending on whether the `=` prefix is given:
```py
>>> struct.calcsize('HI')
8
>>> struct.calcsize('=HI')
6
```

The current code in `Unpacker.unpack()` calls `struct.calcsize()` without the `=` prefix and `struct.unpack_from()` with the `=` prefix.

On my machine `conn.xinput.XIQueryDevice(xcffib.xinput.Device.AllMaster).reply()` throws an exception. Applying this change fixes it and makes it give the right answer. Specifically, the issue appears to be at line 1812 of `xinput.py`:
```py
if self.type == DeviceClassType.Valuator:
    self.number, self.label = unpacker.unpack("HI")
```

(I haven't been able to get `xcffib` to build from scratch. I'm using the Debian package and I just made this modification in the `__init__.py` file in `/usr/lib/python3/dist-packages/xcffib`.)