### PR TITLE
Add py.typed file to installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,17 @@ matrix:
     env: XCBVER=master
   - python: 3.7
     env: XCBVER=master
+  - python: 3.8
+    env: XCBVER=master
   - python: pypy
     env: XCBVER=master
   - python: pypy3
     env: XCBVER=master
-  - python: 3.7
+  - python: 3.8
     env: XCBVER=xcb-proto-1.13
-  - python: 3.7
+  - python: 3.8
     env: XCBVER=1.12
-  - python: 3.7
+  - python: 3.8
     env: XCBVER=1.11
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ GEN=$(CABAL) new-run exe:xcffibgen --
 xcffib: module/*.py
 	$(GEN) --input $(XCBDIR) --output ./xcffib
 	cp ./module/*py ./xcffib/
+	touch ./xcffib/py.typed
 	sed -i "s/__xcb_proto_version__ = .*/__xcb_proto_version__ = \"${XCBVER}\"/" xcffib/__init__.py
 	@if [ "$(TRAVIS)" = true ]; then python xcffib/ffi_build.py; else python xcffib/ffi_build.py > /dev/null 2>&1 || python3 xcffib/ffi_build.py; fi
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     install_requires=dependencies,
     setup_requires=dependencies,
     packages=['xcffib'],
+    package_data={'xcffib': ['py.typed']},
     zip_safe=False,
     cmdclass={
         'build': binding_build,

--- a/setup.py
+++ b/setup.py
@@ -87,9 +87,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries'


### PR DESCRIPTION
In order allow downstream packages to use xcffib to do type resolution, add a py.typed file to the xcffib module.