### PR TITLE
Avoid race in tests

### DIFF
--- a/test/test_python_code.py
+++ b/test/test_python_code.py
@@ -18,6 +18,7 @@ import xcffib.xproto
 import os
 import struct
 import sys
+import time
 from xcffib.xproto import EventMask
 
 from .testing import XcffibTest
@@ -151,6 +152,7 @@ class TestXcffibTestGenerator(object):
             old_display = ""
         # use some non-default width/height
         with XcffibTest(width=1001, height=502) as test:
+            time.sleep(0.1)
             assert os.environ['DISPLAY'] != old_display
             setup = test.conn.get_setup()
             screen = setup.roots[0]


### PR DESCRIPTION
When building openSUSE's python-xcffib package
without this patch on a 1-core VM on a busy host,
tests failed with

```
 FAIL: test_python_code.TestXcffibTestGenerator.test_XcffibTest_generator
 ----------------------------------------------------------------------
 Traceback (most recent call last):
   File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
     self.test(*self.arg)
   File "/home/abuild/rpmbuild/BUILD/xcffib-0.9.0/test/test_python_code.py", lin
e 154, in test_XcffibTest_generator
     assert os.environ['DISPLAY'] != old_display
 AssertionError
```

This PR was done while working on reproducible builds for openSUSE.