### PR TITLE
testing: handle lock file open() failures gracefully

### DIFF
--- a/module/testing.py
+++ b/module/testing.py
@@ -31,11 +31,14 @@ def lock_path(display):
 def find_display():
     display = 10
     while True:
-        f = open(lock_path(display), "w+")
         try:
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            f = open(lock_path(display), "w+")
+            try:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                f.close()
+                raise
         except OSError:
-            f.close()
             display += 1
             continue
         return display, f


### PR DESCRIPTION
Handle lock file open() failures gracefully.  Currently the tests crash
if they can't open the lock file (e.g. because it's owned by somebody
else):

    ======================================================================
    ERROR: test.test_connection.TestConnection.test_ChangeProperty_NET_WM_NAME
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib/python3.9/site-packages/nose/case.py", line 381, in setUp
        try_run(self.inst, ('setup', 'setUp'))
      File "/usr/lib/python3.9/site-packages/nose/util.py", line 471, in try_run
        return func()
      File "/tmp/xcffib-0.10.0/test/test_connection.py", line 33, in setUp
        XvfbTest.setUp(self)
      File "/tmp/xcffib-0.10.0/xcffib/testing.py", line 65, in setUp
        self._display, self._display_lock = find_display()
      File "/tmp/xcffib-0.10.0/xcffib/testing.py", line 34, in find_display
        f = open(lock_path(display), "w+")
    PermissionError: [Errno 13] Permission denied: '/tmp/.X10-lock'