### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/xcffib.cabal
+++ b/xcffib.cabal
@@ -57,8 +57,9 @@ executable xcffibgen
                  mtl >= 2.1,
                  attoparsec,
                  bytestring,
-                 semigroups,
                  either
+  if impl(ghc < 8.0)
+    build-depends: semigroups
   other-modules: Data.XCB.Python.Parse,
                  Data.XCB.Python.PyHelpers
   ghc-options: -Wall


### PR DESCRIPTION
They are not needed on newer GHC.