### PR TITLE
Fix use of pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         name: "python ${{ matrix.python-version }} xcbver ${{ matrix.xcbver }}"
         strategy:
+            fail-fast: false
             matrix:
                 python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
                 xcbver: [1.11, 1.12, xcb-proto-1.13, xcb-proto-1.14, xcb-proto-1.14.1, master]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,4 @@ jobs:
             - run: sudo apt install x11-apps
             - run: git clone https://gitlab.freedesktop.org/xorg/proto/xcbproto.git proto && cd proto && git checkout ${{ matrix.xcbver }}
             - run: make XCBDIR=./proto/src check
+              continue-on-error: ${{ matrix.xcbver == 'master' }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ debian/python-xcffib*
 debian/python3-xcffib*
 .pybuild
 .cabal-sandbox/
+.mypy_cache/
 cabal.sandbox.config
 cabal.project.local*
 .ghc.environment*

--- a/module/testing.py
+++ b/module/testing.py
@@ -44,7 +44,7 @@ def find_display():
         return display, f
 
 
-class XvfbTest(object):
+class XvfbTest:
 
     """ A helper class for testing things with nosetests. This class will run
     each test in its own fresh xvfb, leaving you with an xcffib connection to

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Tycho Andersen
+# Copyright 2021 Sean Vig
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +16,20 @@
 import xcffib
 from xcffib.testing import XvfbTest
 from xcffib.xproto import EventMask
+
+import pytest
+
+
+@pytest.fixture
+def xcffib_test():
+    with XcffibTest() as test_data:
+        yield test_data
+
+
+@pytest.fixture
+def xproto_test(xcffib_test):
+    xcffib_test.xproto = xcffib.xproto.xprotoExtension(xcffib_test.conn)
+    return xcffib_test
 
 
 class XcffibTest(XvfbTest):

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -19,62 +19,65 @@ import xcffib
 import xcffib.xproto
 
 from xcffib import ffi
-from xcffib.testing import XvfbTest
-from .testing import XcffibTest
 
-import struct
+import pytest
 
-class TestConnection(XcffibTest):
 
-    def setUp(self):
-        XvfbTest.setUp(self)
-        self.xproto = xcffib.xproto.xprotoExtension(self.conn)
+class TestConnection:
+    def test_invalid_display(self, xproto_test):
+        with pytest.raises(xcffib.ConnectionException):
+            xproto_test.conn = xcffib.Connection("notvalid")
 
-    def tearDown(self):
-        self.xproto = None
-        XvfbTest.tearDown(self)
-
-    def test_invalid_display(self):
-        try:
-            self.conn = xcffib.Connection('notvalid')
-            self.conn.invalid()
-        except xcffib.ConnectionException:
-            pass
-        else:
-            raise Exception("no connection exception!")
-
-    def test_get_setup(self):
-        setup = self.conn.get_setup()
+    def test_get_setup(self, xproto_test):
+        setup = xproto_test.conn.get_setup()
         # When X upgrades, we can probably manage to change this test :-)
         assert setup.protocol_major_version == 11
         assert setup.protocol_minor_version == 0
 
-    def test_get_screen_pointers(self):
-        screens = self.conn.get_screen_pointers()
+    def test_get_screen_pointers(self, xproto_test):
+        screens = xproto_test.conn.get_screen_pointers()
         assert len(screens) == 1
         screen = screens[0]
         assert ffi.typeof(screen) is ffi.typeof("xcb_screen_t *")
-        assert screen.root == self.default_screen.root
-        assert screen.width_in_pixels == self.width
-        assert screen.height_in_pixels == self.height
-        assert screen.root_depth == self.depth
+        assert screen.root == xproto_test.default_screen.root
+        assert screen.width_in_pixels == xproto_test.width
+        assert screen.height_in_pixels == xproto_test.height
+        assert screen.root_depth == xproto_test.depth
 
-    def test_discard_sequence(self):
-        cookie = self.xproto.GetInputFocus()
+    @pytest.mark.xfail
+    def test_seq_increases(self, xproto_test):
+        # If this test starts failing because the sequence numbers don't mach,
+        # that's probably because you added a new test that imports a new X
+        # extension. When that happens, every new connection automatically does
+        # a QueryExtention for each new ext that has been imported, so the
+        # squence numbers go up by one.
+        #
+        # i.e:
+        # xproto setup query = seqno 0
+        # xtest setup query = seqno 1
+        assert xproto_test.xproto.GetInputFocus().sequence == 2
+        assert xproto_test.xproto.GetInputFocus().sequence == 3
+
+    def test_discard_sequence(self, xproto_test):
+        cookie = xproto_test.xproto.GetInputFocus()
         cookie.discard_reply()
         # this hangs if you leave it in, because the reply really was discarded
         # assert cookie.reply()
 
-    def test_list_extensions(self):
-        reply = self.conn.core.ListExtensions().reply()
+    def test_invalid(self, xproto_test):
+        with pytest.raises(xcffib.ConnectionException):
+            xcffib.Connection("notadisplay")
+
+    def test_list_extensions(self, xproto_test):
+        reply = xproto_test.conn.core.ListExtensions().reply()
         exts = [ext.name.to_string() for ext in reply.names]
         assert "XVideo" in exts
 
-    def test_create_window(self):
-        wid = self.conn.generate_id()
-        cookie = self.create_window(wid=wid)
+    def test_create_window(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        cookie = xproto_test.create_window(wid=wid)
 
-        cookie = self.xproto.GetGeometry(wid)
+        cookie = xproto_test.xproto.GetGeometry(wid)
 
         reply = cookie.reply()
         assert reply.x == 0
@@ -82,120 +85,125 @@ class TestConnection(XcffibTest):
         assert reply.width == 1
         assert reply.height == 1
 
-    def test_wait_for_nonexistent_request(self):
-        try:
-            self.conn.wait_for_reply(10)
-        except xcffib.XcffibException:
-            pass
-        else:
-            raise Exception("xcffib exception expected")
+    def test_wait_for_nonexistent_request(self, xproto_test):
+        with pytest.raises(xcffib.XcffibException):
+            xproto_test.conn.wait_for_reply(10)
 
-    def test_no_windows(self):
+    def test_no_windows(self, xproto_test):
         # Make sure there aren't any windows in the root window. This mostly
         # just exists to make sure people aren't somehow mistakenly running a
         # test in their own X session, which could corrupt results.
-        reply = self.xproto.QueryTree(self.default_screen.root).reply()
+        reply = xproto_test.xproto.QueryTree(xproto_test.default_screen.root).reply()
         assert reply.children_len == 0
         assert len(reply.children) == 0
 
-    def test_create_window_creates_window(self):
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
-        reply = self.xproto.QueryTree(self.default_screen.root).reply()
+    def test_create_window_creates_window(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        xproto_test.create_window(wid=wid)
+        reply = xproto_test.xproto.QueryTree(xproto_test.default_screen.root).reply()
         assert reply.children_len == 1
         assert len(reply.children) == 1
         assert reply.children[0] == wid
 
-    def test_checking_unchecked_fails(self):
-        try:
-            wid = self.conn.generate_id()
-            self.create_window(wid)
-            self.xproto.QueryTreeUnchecked(self.default_screen.root).check()
-        except AssertionError:
-            pass
-        else:
-            raise Exception("expected assertion error")
+    def test_checking_unchecked_fails(self, xproto_test):
+        with pytest.raises(AssertionError):
+            wid = xproto_test.conn.generate_id()
+            xproto_test.create_window(wid)
+            xproto_test.xproto.QueryTreeUnchecked(
+                xproto_test.default_screen.root
+            ).check()
 
-    def test_checking_default_checked_fails(self):
-        try:
-            wid = self.conn.generate_id()
-            self.create_window(wid)
-            cookie = self.xproto.QueryTree(self.default_screen.root)
+    def test_checking_default_checked_fails(self, xproto_test):
+        with pytest.raises(AssertionError):
+            wid = xproto_test.conn.generate_id()
+            xproto_test.create_window(wid)
+            cookie = xproto_test.xproto.QueryTree(xproto_test.default_screen.root)
             cookie.check()
-        except AssertionError:
-            pass
-        else:
-            raise Exception("expected assertion error")
 
-    def test_checking_foreced_checked_succeeds(self):
-        wid = self.conn.generate_id()
-        cookie = self.create_window(wid, is_checked=True)
+    def test_checking_foreced_checked_succeeds(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        cookie = xproto_test.create_window(wid, is_checked=True)
         cookie.check()
 
-    def test_create_window_generates_event(self):
-        self.xeyes()
-        self.conn.flush()
+    def test_create_window_generates_event(self, xproto_test):
+        xproto_test.xeyes()
+        xproto_test.conn.flush()
 
-        e = self.conn.wait_for_event()
+        e = xproto_test.conn.wait_for_event()
         assert isinstance(e, xcffib.xproto.CreateNotifyEvent)
 
-    def test_query_invalid_wid_generates_error(self):
-        try:
+    def test_query_invalid_wid_generates_error(self, xproto_test):
+        with pytest.raises(xcffib.xproto.WindowError):
             # query a bad WINDOW
-            self.xproto.QueryTree(0xf00).reply()
-        except xcffib.xproto.WindowError:
-            pass
-        else:
-            raise Exception("expected WindowError")
+            xproto_test.xproto.QueryTree(0xF00).reply()
 
-    def test_OpenFont(self):
-        fid = self.conn.generate_id()
-        self.xproto.OpenFont(fid, len("cursor"), "cursor")
+    def test_OpenFont(self, xproto_test):
+        fid = xproto_test.conn.generate_id()
+        xproto_test.xproto.OpenFont(fid, len("cursor"), "cursor")
 
-    def test_ConfigureWindow(self):
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
-        self.xproto.ConfigureWindowChecked(wid, 0, []).check()
+    def test_ConfigureWindow(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        xproto_test.create_window(wid=wid)
+        xproto_test.xproto.ConfigureWindowChecked(wid, 0, []).check()
 
-    def test_external_ConfigureWindow(self):
-        self.xeyes()
-        self.conn.flush()
+    def test_external_ConfigureWindow(self, xproto_test):
+        xproto_test.xeyes()
+        xproto_test.conn.flush()
 
-        e = self.conn.wait_for_event()
+        e = xproto_test.conn.wait_for_event()
 
-        r = self.xproto.ConfigureWindowChecked(e.window, 0, []).check()
-        r = self.xproto.DestroyWindowChecked(e.window).check()
+        xproto_test.xproto.ConfigureWindowChecked(e.window, 0, []).check()
+        xproto_test.xproto.DestroyWindowChecked(e.window).check()
 
-    def test_ChangeProperty_WM_NAME(self):
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
+    def test_ChangeProperty_WM_NAME(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        xproto_test.create_window(wid=wid)
 
         title = "test"
-        self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                xcffib.xproto.Atom.WM_NAME, xcffib.xproto.Atom.STRING, 8,
-                len(title), title)
+        xproto_test.xproto.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            wid,
+            xcffib.xproto.Atom.WM_NAME,
+            xcffib.xproto.Atom.STRING,
+            8,
+            len(title),
+            title,
+        )
 
-        reply = self.xproto.GetProperty(False, wid,
-                xcffib.xproto.Atom.WM_NAME, xcffib.xproto.GetPropertyType.Any, 0, 1).reply()
+        reply = xproto_test.xproto.GetProperty(
+            False,
+            wid,
+            xcffib.xproto.Atom.WM_NAME,
+            xcffib.xproto.GetPropertyType.Any,
+            0,
+            1,
+        ).reply()
         assert reply.value.to_string() == title
 
-    def test_ChangeProperty_NET_WM_NAME(self):
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
+    def test_ChangeProperty_NET_WM_NAME(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        xproto_test.create_window(wid=wid)
 
-        net_wm_name = self.intern("_NET_WM_NAME")
-        utf8_string = self.intern("UTF8_STRING")
+        net_wm_name = xproto_test.intern("_NET_WM_NAME")
+        utf8_string = xproto_test.intern("UTF8_STRING")
 
         title_bytes = b"test\xc2\xb7"
         title_string = six.u("test\u00B7")
 
         # First check with an object already encoded as bytes
-        self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                net_wm_name, utf8_string, 8,
-                len(title_bytes), title_bytes)
+        xproto_test.xproto.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            wid,
+            net_wm_name,
+            utf8_string,
+            8,
+            len(title_bytes),
+            title_bytes,
+        )
 
-        reply = self.xproto.GetProperty(False, wid,
-                net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1).reply()
+        reply = xproto_test.xproto.GetProperty(
+            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1
+        ).reply()
 
         print(reply.value.buf())
         assert reply.value.buf() == title_bytes
@@ -203,106 +211,126 @@ class TestConnection(XcffibTest):
         assert reply.value.to_utf8() == title_string
 
         # Also check with a unicode string
-        self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                net_wm_name, utf8_string, 8,
-                len(title_string.encode('utf-8')), title_string)
+        xproto_test.xproto.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            wid,
+            net_wm_name,
+            utf8_string,
+            8,
+            len(title_string.encode("utf-8")),
+            title_string,
+        )
 
-        reply = self.xproto.GetProperty(False, wid,
-                net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1).reply()
+        reply = xproto_test.xproto.GetProperty(
+            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1
+        ).reply()
 
         assert reply.value.buf() == title_bytes
         assert reply.value.to_utf8() == title_string
 
-    def test_ChangeProperty_WM_PROTOCOLS(self):
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
+    def test_ChangeProperty_WM_PROTOCOLS(self, xproto_test):
+        wid = xproto_test.conn.generate_id()
+        xproto_test.create_window(wid=wid)
 
-        wm_protocols = self.intern("WM_PROTOCOLS")
+        wm_protocols = xproto_test.intern("WM_PROTOCOLS")
 
-        wm_delete_window = self.intern("WM_DELETE_WINDOW")
+        wm_delete_window = xproto_test.intern("WM_DELETE_WINDOW")
 
-        self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                wm_protocols, xcffib.xproto.Atom.ATOM, 32,
-                1, (wm_delete_window,))
-        # For Python 2 only, make sure packing can handle both ints and longs
-        if six.PY2:
-            self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                    wm_protocols, xcffib.xproto.Atom.ATOM, 32,
-                    1, (long(wm_delete_window),))
+        xproto_test.xproto.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            wid,
+            wm_protocols,
+            xcffib.xproto.Atom.ATOM,
+            32,
+            1,
+            (wm_delete_window,),
+        )
 
-        reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
+        reply = xproto_test.xproto.GetProperty(
+            False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1
+        ).reply()
 
         assert reply.value.to_atoms() == (wm_delete_window,)
 
-        wm_take_focus = self.intern("WM_TAKE_FOCUS")
+        wm_take_focus = xproto_test.intern("WM_TAKE_FOCUS")
 
-        self.xproto.ChangeProperty(xcffib.xproto.PropMode.Replace, wid,
-                wm_protocols, xcffib.xproto.Atom.ATOM, 32,
-                1, (wm_take_focus,))
+        xproto_test.xproto.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            wid,
+            wm_protocols,
+            xcffib.xproto.Atom.ATOM,
+            32,
+            1,
+            (wm_take_focus,),
+        )
 
-        reply = self.xproto.GetProperty(False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1).reply()
+        reply = xproto_test.xproto.GetProperty(
+            False, wid, wm_protocols, xcffib.xproto.Atom.ATOM, 0, 1
+        ).reply()
 
         assert reply.value.to_atoms() == (wm_take_focus,)
 
-    def test_GetAtomName(self):
+    def test_GetAtomName(self, xproto_test):
         wm_protocols = "WM_PROTOCOLS"
-        atom = self.intern(wm_protocols)
-        atom_name = self.xproto.GetAtomName(atom).reply().name
+        atom = xproto_test.intern(wm_protocols)
+        atom_name = xproto_test.xproto.GetAtomName(atom).reply().name
 
         assert atom_name.to_string() == wm_protocols
 
-    def test_KillClient(self):
-        self.xeyes()
+    def test_KillClient(self, xproto_test):
+        xproto_test.xeyes()
 
-        self.conn.flush()
+        xproto_test.conn.flush()
 
-        e1 = self.conn.wait_for_event()
-        self.xproto.KillClient(e1.window)
+        e1 = xproto_test.conn.wait_for_event()
+        xproto_test.xproto.KillClient(e1.window)
 
         # one is MapRequest and the other is DestroyNotify, they may be in
         # either order
         for _ in range(2):
-            self.conn.flush()
-            k1 = self.conn.wait_for_event()
+            xproto_test.conn.flush()
+            k1 = xproto_test.conn.wait_for_event()
             if isinstance(k1, xcffib.xproto.DestroyNotifyEvent):
                 assert e1.window == k1.window
                 return
         assert False, "no DestroyNotifyEvent"
 
-    def test_connect(self):
+    def test_connect(self, xproto_test):
         c = xcffib.connect()
         c.invalid()
         assert c.has_error() == 0
         c.disconnect()
 
-    def test_auth_connect(self):
+    def test_auth_connect(self, xproto_test):
         authname = six.b("MIT-MAGIC-COOKIE-1")
-        authdata = six.b("\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47")
+        authdata = six.b(
+            "\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47"
+        )
 
-        authstr = authname + six.b(':') + authdata
+        authstr = authname + six.b(":") + authdata
 
-        conn = xcffib.connect(display=os.environ['DISPLAY'], auth=authstr)
+        conn = xcffib.connect(display=os.environ["DISPLAY"], auth=authstr)
 
         assert conn.get_setup().roots[0].root > 0
 
     # This is an adaptation of the test from #27
-    def test_build_atom_cache(self):
+    def test_build_atom_cache(self, xproto_test):
         # This will hold the forward *and* reverse lookups for any given atom
         atoms = {}
         cookies = []
         # Batch the replies by creating a list of cookies first:
         for i in range(1, 10000):
-            c = self.conn.core.GetAtomName(i)
+            c = xproto_test.conn.core.GetAtomName(i)
             cookies.append((i, c))
         for i, c in cookies:
             try:
                 name = c.reply().name.to_string()
             except xcffib.xproto.BadAtom:
                 continue
-            atoms.update({i: name}) # Lookup by number
-            atoms.update({name: i}) # Lookup by name
+            atoms.update({i: name})  # Lookup by number
+            atoms.update({name: i})  # Lookup by name
 
-    def test_wrap(self):
+    def test_wrap(self, xproto_test):
         c = xcffib.connect()
         c.invalid()
         c2 = xcffib.wrap(xcffib.ffi.cast("long", c._conn))

--- a/test/test_crazy_window_script.py
+++ b/test/test_crazy_window_script.py
@@ -23,7 +23,6 @@
 """
     This is mostly stolen from qtile's tests/scripts/window.py
 """
-from __future__ import print_function
 import os
 import sys
 import struct
@@ -31,15 +30,14 @@ import time
 import xcffib
 import xcffib.xproto
 from xcffib.xproto import EventMask
-from xcffib.testing import XvfbTest
 
-class TestWindow(XvfbTest):
 
-    def test_the_script(self):
+class TestWindow:
+    def test_the_script(self, xcffib_test):
         NAME = "one"
         for i in range(20):
             try:
-                conn = xcffib.connect(os.environ['DISPLAY'])
+                conn = xcffib.connect(os.environ["DISPLAY"])
             except xcffib.ConnectionException:
                 time.sleep(0.1)
                 continue
@@ -48,51 +46,104 @@ class TestWindow(XvfbTest):
                 sys.exit(1)
             break
         else:
-            print("Could not open window on display %s" % (sys.argv[1]), file=sys.stderr)
+            print(
+                "Could not open window on display %s" % (sys.argv[1]), file=sys.stderr
+            )
             sys.exit(1)
 
         screen = conn.get_setup().roots[conn.pref_screen]
 
         window = conn.generate_id()
-        background = conn.core.AllocColor(screen.default_colormap, 0x2828, 0x8383, 0xCECE).reply().pixel # Color "#2883ce"
-        conn.core.CreateWindow(xcffib.CopyFromParent, window, screen.root,
-                100, 100, 100, 100, 1,
-                xcffib.xproto.WindowClass.InputOutput, screen.root_visual,
-                xcffib.xproto.CW.BackPixel | xcffib.xproto.CW.EventMask,
-                [background, xcffib.xproto.EventMask.StructureNotify | xcffib.xproto.EventMask.Exposure])
+        background = (
+            conn.core.AllocColor(screen.default_colormap, 0x2828, 0x8383, 0xCECE)
+            .reply()
+            .pixel
+        )  # Color "#2883ce"
+        conn.core.CreateWindow(
+            xcffib.CopyFromParent,
+            window,
+            screen.root,
+            100,
+            100,
+            100,
+            100,
+            1,
+            xcffib.xproto.WindowClass.InputOutput,
+            screen.root_visual,
+            xcffib.xproto.CW.BackPixel | xcffib.xproto.CW.EventMask,
+            [
+                background,
+                xcffib.xproto.EventMask.StructureNotify
+                | xcffib.xproto.EventMask.Exposure,
+            ],
+        )
 
-        conn.core.ChangeProperty(xcffib.xproto.PropMode.Replace,
-                window, xcffib.xproto.Atom.WM_NAME,
-                xcffib.xproto.Atom.STRING, 8, len(NAME),
-                NAME)
+        conn.core.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            window,
+            xcffib.xproto.Atom.WM_NAME,
+            xcffib.xproto.Atom.STRING,
+            8,
+            len(NAME),
+            NAME,
+        )
 
         wm_protocols = "WM_PROTOCOLS"
-        wm_protocols = conn.core.InternAtom(0, len(wm_protocols), wm_protocols).reply().atom
+        wm_protocols = (
+            conn.core.InternAtom(0, len(wm_protocols), wm_protocols).reply().atom
+        )
 
         wm_delete_window = "WM_DELETE_WINDOW"
-        wm_delete_window = conn.core.InternAtom(0, len(wm_delete_window), wm_delete_window).reply().atom
+        wm_delete_window = (
+            conn.core.InternAtom(0, len(wm_delete_window), wm_delete_window)
+            .reply()
+            .atom
+        )
 
-        conn.core.ChangeProperty(xcffib.xproto.PropMode.Replace,
-                window, wm_protocols,
-                xcffib.xproto.Atom.ATOM, 32, 1,
-                [wm_delete_window])
+        conn.core.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            window,
+            wm_protocols,
+            xcffib.xproto.Atom.ATOM,
+            32,
+            1,
+            [wm_delete_window],
+        )
 
-        conn.core.ConfigureWindow(window,
-                xcffib.xproto.ConfigWindow.X | xcffib.xproto.ConfigWindow.Y |
-                xcffib.xproto.ConfigWindow.Width | xcffib.xproto.ConfigWindow.Height |
-                xcffib.xproto.ConfigWindow.BorderWidth,
-                [0, 0, 100, 100, 1])
+        conn.core.ConfigureWindow(
+            window,
+            xcffib.xproto.ConfigWindow.X
+            | xcffib.xproto.ConfigWindow.Y
+            | xcffib.xproto.ConfigWindow.Width
+            | xcffib.xproto.ConfigWindow.Height
+            | xcffib.xproto.ConfigWindow.BorderWidth,
+            [0, 0, 100, 100, 1],
+        )
         conn.core.MapWindow(window)
         conn.flush()
-        conn.core.ConfigureWindow(window,
-                xcffib.xproto.ConfigWindow.X | xcffib.xproto.ConfigWindow.Y |
-                xcffib.xproto.ConfigWindow.Width | xcffib.xproto.ConfigWindow.Height |
-                xcffib.xproto.ConfigWindow.BorderWidth,
-                [0, 0, 100, 100, 1])
+        conn.core.ConfigureWindow(
+            window,
+            xcffib.xproto.ConfigWindow.X
+            | xcffib.xproto.ConfigWindow.Y
+            | xcffib.xproto.ConfigWindow.Width
+            | xcffib.xproto.ConfigWindow.Height
+            | xcffib.xproto.ConfigWindow.BorderWidth,
+            [0, 0, 100, 100, 1],
+        )
 
         # now kill the window from the "wm" side via WM_DELETE_WINDOW protocol
-        WM_PROTOCOLS = self.conn.core.InternAtom(False, len("WM_PROTOCOLS"), "WM_PROTOCOLS").reply().atom
-        WM_DELETE_WINDOW = self.conn.core.InternAtom(False, len("WM_DELETE_WINDOW"), "WM_DELETE_WINDOW").reply().atom
+        WM_PROTOCOLS = (
+            xcffib_test.conn.core.InternAtom(False, len("WM_PROTOCOLS"), "WM_PROTOCOLS")
+            .reply()
+            .atom
+        )
+        WM_DELETE_WINDOW = (
+            xcffib_test.conn.core.InternAtom(
+                False, len("WM_DELETE_WINDOW"), "WM_DELETE_WINDOW"
+            )
+            .reply()
+            .atom
+        )
         vals = [
             33,  # ClientMessageEvent
             32,  # Format
@@ -105,10 +156,10 @@ class TestWindow(XvfbTest):
             0,
             0,
         ]
-        e = struct.pack('BBHII5I', *vals)
-        self.conn.core.SendEvent(False, window, EventMask.NoEvent, e)
+        e = struct.pack("BBHII5I", *vals)
+        xcffib_test.conn.core.SendEvent(False, window, EventMask.NoEvent, e)
 
-        self.conn.flush()
+        xcffib_test.conn.flush()
 
         while 1:
             conn.flush()

--- a/test/test_fakeinput.py
+++ b/test/test_fakeinput.py
@@ -2,46 +2,45 @@ import xcffib
 import xcffib.xproto
 import xcffib.xtest
 
-from .testing import XcffibTest
 
-class TestConnection(XcffibTest):
-    def test_fakeinput(self):
-        xtest = self.conn(xcffib.xtest.key)
+def test_fakeinput(xcffib_test):
+    xtest = xcffib_test.conn(xcffib.xtest.key)
 
-        setup = self.conn.get_setup()
-        screen = setup.roots[0]
-        def test(x, y):
-            # motion
-            xtest.FakeInput(
-                6,
-                0,
-                xcffib.xproto.Time.CurrentTime,
-                screen.root,
-                x,
-                y,
-                0)
+    setup = xcffib_test.conn.get_setup()
+    screen = setup.roots[0]
 
-            # press
-            xtest.FakeInput(
-                4,
-                1,
-                xcffib.xproto.Time.CurrentTime,
-                screen.root,
-                0,
-                0,
-                0)
+    def test(x, y):
+        # motion
+        xtest.FakeInput(
+            6,
+            0,
+            xcffib.xproto.Time.CurrentTime,
+            screen.root,
+            x,
+            y,
+            0)
 
-            # release
-            xtest.FakeInput(
-                5,
-                1,
-                xcffib.xproto.Time.CurrentTime,
-                screen.root,
-                2,
-                2,
-                0)
-            self.conn.flush()
-        test(50, 10)
+        # press
+        xtest.FakeInput(
+            4,
+            1,
+            xcffib.xproto.Time.CurrentTime,
+            screen.root,
+            0,
+            0,
+            0)
 
-        # we shouldn't get any errors
-        self.conn.poll_for_event()
+        # release
+        xtest.FakeInput(
+            5,
+            1,
+            xcffib.xproto.Time.CurrentTime,
+            screen.root,
+            2,
+            2,
+            0)
+        xcffib_test.conn.flush()
+    test(50, 10)
+
+    # we shouldn't get any errors
+    xcffib_test.conn.poll_for_event()

--- a/test/test_python_code.py
+++ b/test/test_python_code.py
@@ -20,9 +20,10 @@ import struct
 import sys
 from xcffib.xproto import EventMask
 
-from .testing import XcffibTest
+from .conftest import XcffibTest
 
-class TestPythonCode(XcffibTest):
+
+class TestPythonCode:
 
     def test_struct_pack_uses_List(self):
         # suppose we have a list of ints...
@@ -65,9 +66,9 @@ class TestPythonCode(XcffibTest):
         assert om[1] == "Event1,0"
         assert om[2] == "Event1,1"
 
-    def test_create_ClientMessageEvent(self):
-        wm_protocols = self.intern("WM_PROTOCOLS")
-        wm_delete_window = self.intern("WM_DELETE_WINDOW")
+    def test_create_ClientMessageEvent(self, xcffib_test):
+        wm_protocols = xcffib_test.intern("WM_PROTOCOLS")
+        wm_delete_window = xcffib_test.intern("WM_DELETE_WINDOW")
 
         # should be exactly 20 bytes
         data = [
@@ -81,11 +82,11 @@ class TestPythonCode(XcffibTest):
         union = xcffib.xproto.ClientMessageData.synthetic(data, "I" * 5)
         assert list(union.data32) == data
 
-        wid = self.conn.generate_id()
-        self.create_window(wid=wid)
+        wid = xcffib_test.conn.generate_id()
+        xcffib_test.create_window(wid=wid)
 
-        wm_protocols = self.intern("WM_PROTOCOLS")
-        wm_delete_window = self.intern("WM_DELETE_WINDOW")
+        wm_protocols = xcffib_test.intern("WM_PROTOCOLS")
+        wm_delete_window = xcffib_test.intern("WM_DELETE_WINDOW")
 
         e = xcffib.xproto.ClientMessageEvent.synthetic(
             format=32,
@@ -94,18 +95,18 @@ class TestPythonCode(XcffibTest):
             data=union
         )
 
-        self.xproto.SendEvent(False, wid, EventMask.NoEvent, e.pack())
-        self.conn.flush()
+        xcffib_test.xproto.SendEvent(False, wid, EventMask.NoEvent, e.pack())
+        xcffib_test.conn.flush()
 
-        e = self.conn.wait_for_event()
+        e = xcffib_test.conn.wait_for_event()
         assert isinstance(e, xcffib.xproto.ClientMessageEvent)
         assert e.window == wid
         assert list(e.data.data32) == data
 
-    def test_pack_from_event(self):
-        wm_protocols = self.intern("WM_PROTOCOLS")
-        wm_delete_window = self.intern("WM_DELETE_WINDOW")
-        wid = self.conn.generate_id()
+    def test_pack_from_event(self, xcffib_test):
+        wm_protocols = xcffib_test.intern("WM_PROTOCOLS")
+        wm_delete_window = xcffib_test.intern("WM_DELETE_WINDOW")
+        wid = xcffib_test.conn.generate_id()
 
         # should be exactly 20 bytes
         data = [
@@ -126,9 +127,9 @@ class TestPythonCode(XcffibTest):
 
         e2 = xcffib.xproto.ClientMessageEvent(e)
 
-    def test_get_image(self):
+    def test_get_image(self, xcffib_test):
         # adapted from: https://gist.github.com/liftoff/4741790
-        setup = self.conn.get_setup()
+        setup = xcffib_test.conn.get_setup()
         screen = setup.roots[0]
         width = screen.width_in_pixels
         height = screen.height_in_pixels
@@ -137,12 +138,12 @@ class TestPythonCode(XcffibTest):
         # GetImage requires an output format as the first arg.  We want ZPixmap:
         output_format = xcffib.xproto.ImageFormat.ZPixmap
         plane_mask = 2**32 - 1 # No idea what this is but it works!
-        reply = self.conn.core.GetImage(
+        reply = xcffib_test.conn.core.GetImage(
             output_format, root, 0, 0, width, height, plane_mask).reply()
         reply.data.buf()
 
 
-class TestXcffibTestGenerator(object):
+class TestXcffibTestGenerator:
 
     def test_XcffibTest_generator(self):
         try:


### PR DESCRIPTION
Wrap the base Xcffib test class which sets up and tears down the xcffib
connection in a pytest fixture rather than having the tests inherit from
the test class.  This allows all of the tests to be run through the
pytest runner as expected.