### PR TITLE
ci: switch python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+                python-version: [3.7, 3.8, 3.9, "3.10", pypy3]
                 xcbver: [xcb-proto-1.13, xcb-proto-1.14, xcb-proto-1.14.1, master]
         steps:
             - uses: actions/checkout@v2
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python "${{ matrix.python-version }}"
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: "${{ matrix.python-version }}"
             - uses: actions/setup-haskell@v1.1.3
               with:
                   ghc-version: 8.10


### PR DESCRIPTION
3.6 is EOL in two months (and I don't know of anyone using it anyway).

3.10 was just released, so let's test it.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>