### PR TITLE
build: bump haskell versions of things

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,10 @@ jobs:
               uses: actions/setup-python@v2
               with:
                   python-version: "${{ matrix.python-version }}"
-            - uses: actions/setup-haskell@v1.1.3
+            - uses: haskell/actions/setup@v1
               with:
-                  ghc-version: 8.10
-                  cabal-version: 3.2
+                  ghc-version: 9.0
+                  cabal-version: 3.4
             - run: cabal update
             - run: pip install -r requirements.txt
             - run: pip install pytest


### PR DESCRIPTION
These:

Configuring test suite 'PyHelpersTests' for xcffib-0.11.1..
Warning: The package has an extraneous version range for a dependency on an
internal library: xcffib >=0 && ==0.11.1, xcffib >=0 && ==0.11.1. This version
range includes the current package but isn't needed as the current package's
library will always be used.

are apparently known issues that will be fixed.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>