### PR TITLE
[WIP] Better handling of GeGenericEvents

### DIFF
--- a/generator/Data/XCB/Python/PyHelpers.hs
+++ b/generator/Data/XCB/Python/PyHelpers.hs
@@ -134,15 +134,16 @@ mkParams = map (\x -> Param (ident x) Nothing Nothing ())
 mkArg :: String -> Argument ()
 mkArg n = ArgExpr (mkName n) ()
 
-mkXClass :: String -> String -> Suite () -> Suite () -> Statement ()
-mkXClass clazz superclazz [] [] = mkEmptyClass clazz superclazz
-mkXClass clazz superclazz constructor methods =
+mkXClass :: String -> String -> Bool -> Suite () -> Suite () -> Statement ()
+mkXClass clazz superclazz False [] [] = mkEmptyClass clazz superclazz
+mkXClass clazz superclazz xge constructor methods =
   let args = [ "self", "unpacker" ]
       super = mkCall (superclazz ++ ".__init__") $ map mkName args
       body = eventToUnpacker : (StmtExpr super ()) : constructor
       initParams = mkParams args
+      xgeexp = mkAssign "xge" (if xge then (mkName "True") else (mkName "False"))
       initMethod = Fun (ident "__init__") initParams Nothing body ()
-  in mkClass clazz superclazz $ initMethod : methods
+  in mkClass clazz superclazz $ xgeexp : initMethod : methods
 
     where
 

--- a/module/ffi_build.py
+++ b/module/ffi_build.py
@@ -15,7 +15,6 @@
 
 from cffi import FFI
 
-
 CONSTANTS = [
     ("X_PROTOCOL", 11),
     ("X_PROTOCOL_REVISION", 0),

--- a/module/testing.py
+++ b/module/testing.py
@@ -15,11 +15,11 @@
 # Not strictly necessary to be included with the binding, but may be useful for
 # others who want to test things using xcffib.
 
+import errno
 import fcntl
 import os
-import time
-import errno
 import subprocess
+import time
 
 from . import Connection, ConnectionException
 

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -7,6 +7,7 @@ key = xcffib.ExtensionKey("ERROR")
 _events = {}
 _errors = {}
 class RequestError(xcffib.Error):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -7,6 +7,7 @@ key = xcffib.ExtensionKey("EVENT")
 _events = {}
 _errors = {}
 class ScreenChangeNotifyEvent(xcffib.Event):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class KeymapNotifyEvent(xcffib.Event):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -7,6 +7,7 @@ key = xcffib.ExtensionKey("RENDER")
 _events = {}
 _errors = {}
 class COLOR(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -28,6 +29,7 @@ class COLOR(xcffib.Struct):
         self.alpha = alpha
         return self
 class RECTANGLE(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class STR(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -24,6 +25,7 @@ class STR(xcffib.Struct):
         self.name = name
         return self
 class ListExtensionsReply(xcffib.Reply):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class AxisInfo(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -24,6 +25,7 @@ class AxisInfo(xcffib.Struct):
         self.maximum = maximum
         return self
 class ValuatorInfo(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class INT64(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -23,6 +24,7 @@ class INT64(xcffib.Struct):
         self.lo = lo
         return self
 class GetPropertyReply(xcffib.Reply):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -39,6 +41,7 @@ class GetPropertyReply(xcffib.Reply):
 class GetPropertyCookie(xcffib.Cookie):
     reply_type = GetPropertyReply
 class GetPropertyWithPadReply(xcffib.Reply):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class CHARINFO(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -27,6 +28,7 @@ class CHARINFO(xcffib.Struct):
         self.attributes = attributes
         return self
 class FONTPROP(xcffib.Struct):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -46,6 +48,7 @@ class FONTPROP(xcffib.Struct):
         self.value = value
         return self
 class ListFontsWithInfoReply(xcffib.Reply):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/generator/union.py
+++ b/test/generator/union.py
@@ -4,6 +4,7 @@ import io
 _events = {}
 _errors = {}
 class ClientMessageData(xcffib.Union):
+    xge = False
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -53,8 +53,8 @@ class TestConnection:
         # i.e:
         # xproto setup query = seqno 0
         # xtest setup query = seqno 1
-        assert xproto_test.xproto.GetInputFocus().sequence == 3
-        assert xproto_test.xproto.GetInputFocus().sequence == 4
+        assert xproto_test.xproto.GetInputFocus().sequence == 6
+        assert xproto_test.xproto.GetInputFocus().sequence == 7
 
     def test_discard_sequence(self, xproto_test):
         cookie = xproto_test.xproto.GetInputFocus()

--- a/xcffib.cabal
+++ b/xcffib.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 library
   build-depends: base ==4.*,
-                 xcb-types >= 0.11.0,
+                 xcb-types >= 0.12.0,
                  language-python >= 0.5.6,
                  filepath,
                  filemanip,
@@ -48,7 +48,7 @@ executable xcffibgen
                  xcffib,
                  language-python >= 0.5.6,
                  split,
-                 xcb-types >= 0.11.0,
+                 xcb-types >= 0.12.0,
                  optparse-applicative >= 0.13,
                  filepath,
                  filemanip,
@@ -83,7 +83,7 @@ test-suite GeneratorTests.hs
   type: exitcode-stdio-1.0
   build-depends: base ==4.*,
                  xcffib,
-                 xcb-types >= 0.11.0,
+                 xcb-types >= 0.12.0,
                  language-python >= 0.5.6,
                  HUnit,
                  test-framework,


### PR DESCRIPTION
This is a work in progress but I wanted to post this here as I have some questions and need some help!

For background, I've abandoned the "updating xcbproto" approach. The reason for this is that their `xcbgen` code looks for a `xge="True"` attribute in the xml files and then does some additional steps to extract the additional fields. So, if I wanted to amend the xml files, I'd have to amend *every* definition that includes that `xge` attribute.

So, instead, I've tried to replicate that approach by looking to see if we're a `GeGenericEvent` type and, if so, do some more field unpacking. This allows me to successfully create a `GeGenericEvent` with the right fields.

However, when I try to hoist these to the appropriate extension event, I run into an issue: the data in the hoisted event is not correct.

I am pretty sure this is due to the way the data is being unpacked by `xcffib` but I am completely new when it comes to `struct`s and am struggling a bit.

The `xcb_ge_generic_event_t` definition looks like this:
```
typedef struct xcb_ge_generic_event_t {
     uint8_t  response_type;
     uint8_t  extension;
     uint16_t sequence;
     uint32_t length;
     uint16_t event_type;
     uint8_t  pad0[22];
     uint32_t full_sequence;
} xcb_ge_generic_event_t 
```

In the python code, I unpack this with this line:
``` python
self.extension, self.length, self.event_type, self.full_sequence = unpacker.unpack("xB2xIH22xI")
```

As an example, looking at the `BarrierHitEvent`, the source is as follows:
```
typedef struct xcb_input_barrier_hit_event_t {
    uint8_t               response_type;
    uint8_t               extension;
    uint16_t              sequence;
    uint32_t              length;
    uint16_t              event_type;
    xcb_input_device_id_t deviceid;
    xcb_timestamp_t       time;
    uint32_t              eventid;
    xcb_window_t          root;
    xcb_window_t          event;
    xcb_xfixes_barrier_t  barrier;
    uint32_t              full_sequence;
    uint32_t              dtime;
    uint32_t              flags;
    xcb_input_device_id_t sourceid;
    uint8_t               pad0[2];
    xcb_input_fp1616_t    root_x;
    xcb_input_fp1616_t    root_y;
    xcb_input_fp3232_t    dx;
    xcb_input_fp3232_t    dy;
} xcb_input_barrier_hit_event_t;
```

In the python file, we have this code:
``` python
        xcffib.Event.__init__(self, unpacker)
        base = unpacker.offset
        self.deviceid, self.time, self.eventid, self.root, self.event, self.barrier, self.dtime, self.flags, self.sourceid, self.root_x, self.root_y = unpacker.unpack("xx2xHIIIIIIIH2xii")
        self.dx = FP3232(unpacker)
        unpacker.pad(FP3232)
        self.dy = FP3232(unpacker)
```

The `xcffib.Event.__init__(self, unpacker)` line will include the previous unpacking (above).

I can see that the `GeGenericEvent` unpacking has a large bit of padding before the `full_sequence` field. In the barrier hit definition, there are numerous fields in this gap which need to be unpacked by `BarrierHitEvent`. The unpacker seems to have some padding at the start of it but it doesn't correspond to `GeGenericEvent` definition so I'm not sure how to handle this.

I'm assuming I need to adjust the `unpacker.offset` value after unpacking the `GeGenericEvent` but I can't work out what that adjustment needs to be.

Any pointers would be greatly appreciated.


Problem 2:

I'm also struggling to send a `GeGenericEvent` in a test but let's leave that for now...

