### PR TITLE
ci: test with xcb-proto 1.15.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [3.7, 3.8, 3.9, "3.10", pypy3]
-                xcbver: [xcb-proto-1.13, xcb-proto-1.14, xcb-proto-1.14.1, xcb-proto-1.15, master]
+                xcbver: [xcb-proto-1.14, xcb-proto-1.14.1, xcb-proto-1.15, xcb-proto-1.15.1, master]
         steps:
             - uses: actions/checkout@v2
             - name: Set up python "${{ matrix.python-version }}"


### PR DESCRIPTION
Let's also drop support for 1.13. Bionic still uses this, but it has less
than a year of life left, and my assumption is that most desktop users are
on something more bleeding-edge.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>