### PR TITLE
ci: test latest of each branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [3.7, 3.8, 3.9, "3.10", pypy3]
-                xcbver: [xcb-proto-1.14, xcb-proto-1.14.1, xcb-proto-1.15, xcb-proto-1.15.1, master]
+                xcbver: [xcb-proto-1.14.1, xcb-proto-1.15.2, master]
         steps:
             - uses: actions/checkout@v2
             - name: Set up python "${{ matrix.python-version }}"


### PR DESCRIPTION
there was a 1.15.2 branch, so let's test that. doesn't seem like we need to
test 1.15 and 1.15.1 though, so let's reduce the matrix so it's just the
1.14 series and 1.15 series being tested.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>