### PR TITLE
build: move to pytest-3 binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,6 @@ jobs:
                   cabal-version: 3.4
             - run: cabal update
             - run: pip install -r requirements.txt
-            - run: pip install pytest
-            - run: sudo apt install x11-apps
+            - run: sudo apt install x11-apps python3-pytest
             - run: git clone https://gitlab.freedesktop.org/xorg/proto/xcbproto.git proto && cd proto && git checkout ${{ matrix.xcbver }}
             - run: make XCBDIR=./proto/src check

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ htests:
 	$(CABAL) new-test -j$(NCPUS) --enable-tests
 
 check: xcffib lint htests
-	pytest -v
+	pytest-3 -v
 
 # make release ver=0.99.99
 release: xcffib


### PR DESCRIPTION
Our CI helpfully exports pytest-3 as pytest, but in the default ubuntu
packaging this is not present any more. let's just rename this to pytest-3
so it works on normal hosts too.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>