### PR TITLE
tests: wait for response from ChangeWindowattributes()

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -68,7 +68,7 @@ class XcffibTest(XvfbTest):
 
     def xeyes(self):
         # Enable CreateNotify
-        self.xproto.ChangeWindowAttributes(
+        self.xproto.ChangeWindowAttributesChecked(
             self.default_screen.root,
             xcffib.xproto.CW.EventMask,
             [
@@ -76,7 +76,7 @@ class XcffibTest(XvfbTest):
                 EventMask.StructureNotify |
                 EventMask.SubstructureRedirect
             ]
-        )
+        ).check()
 
         self.spawn(['xeyes'])
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -127,7 +127,6 @@ class TestConnection:
 
     def test_create_window_generates_event(self, xproto_test):
         xproto_test.xeyes()
-        xproto_test.conn.flush()
 
         e = xproto_test.conn.wait_for_event()
         assert isinstance(e, xcffib.xproto.CreateNotifyEvent)
@@ -148,7 +147,6 @@ class TestConnection:
 
     def test_external_ConfigureWindow(self, xproto_test):
         xproto_test.xeyes()
-        xproto_test.conn.flush()
 
         e = xproto_test.conn.wait_for_event()
 
@@ -279,8 +277,6 @@ class TestConnection:
 
     def test_KillClient(self, xproto_test):
         xproto_test.xeyes()
-
-        xproto_test.conn.flush()
 
         e1 = xproto_test.conn.wait_for_event()
         xproto_test.xproto.KillClient(e1.window)


### PR DESCRIPTION
every once in a while, we see an indefinite hang in the tests. nobody has
ever complained about anything like that in the actual binding, so it
stands to reason the bug is actually in the tests.

my best guess is the following:

1. ChangeWindowAttributes() to get map/create/destroy events
2. spawn xeyes
3. flush the connection

If xeyes happened to spawn and its events triggered before the connection
got flushed and the monitoring of events actually enabled, we could
conceivably miss these events and hang forever. instead, let's use a
checked request for the ChangeWindowAttributes() part, and check the
result. then we don't need these heavy-weight flushes (that were in the
wrong order anyway... at all)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>