### PR TITLE
tests: drop xfail

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -44,7 +44,6 @@ class TestConnection:
         assert screen.height_in_pixels == xproto_test.height
         assert screen.root_depth == xproto_test.depth
 
-    @pytest.mark.xfail
     def test_seq_increases(self, xproto_test):
         # If this test starts failing because the sequence numbers don't mach,
         # that's probably because you added a new test that imports a new X


### PR DESCRIPTION
It looks like this was added during the pytest migration perhaps in error.
I ran the test suite ten times with out it and it passed, so hopefully i'm
not just super lucky :)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>