### PR TITLE
ci: use "latest" version of haskell packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
                   python-version: "${{ matrix.python-version }}"
             - uses: haskell/actions/setup@v1
               with:
-                  ghc-version: 9.0
-                  cabal-version: 3.4
+                  ghc-version: latest
+                  cabal-version: latest
             - run: cabal update
             - run: pip install -r requirements.txt
             - run: pip install pytest


### PR DESCRIPTION
We mostly don't worry about building the haskell code with various
compilers, as it doesn't change very much any more. As such, it's annoying
to keep having these version bump PRs for haskell versions. Let's just
build with "latest", and hopefully there won't be too much build breakage.
Of course we can revert to setting specific versions if it turns out there
is... but I sort of doubt it.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>