### PR TITLE
build: upgrade valgrind target to use pytest-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	-rm -rf .pc cabal.project.local*
 
 valgrind: xcffib
-	valgrind --leak-check=full --show-leak-kinds=definite pytest -v
+	valgrind --leak-check=full --show-leak-kinds=definite pytest-3 -v
 
 newtests:
 	$(GEN) --input ./test/generator/ --output ./test/generator/


### PR DESCRIPTION
derp, forgot this in the patch where I updated the check target.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>