### PR TITLE
testing: fix typo

### DIFF
--- a/module/testing.py
+++ b/module/testing.py
@@ -83,7 +83,7 @@ class XvfbTest:
         try:
             self.conn = self._connect_to_xvfb()
         except AssertionError:
-            self._restore_dislpay()
+            self._restore_display()
             raise
 
     def tearDown(self):


### PR DESCRIPTION
Got another CI failure from an overloaded host (how is 20 seconds not
enough?!):

https://github.com/tych0/xcffib/runs/7490425253?check_suite_focus=true

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = <test.conftest.XcffibTest object at 0x7ff1b4899d00>
    def setUp(self):
        self._old_display = os.environ.get('DISPLAY')
        self._display, self._display_lock = find_display()
        os.environ['DISPLAY'] = ':%d' % self._display
        self._xvfb = self.spawn(self._xvfb_command())
        if self.xtrace:
            subprocess.Popen(['xtrace', '-n'])
            # xtrace's default display is :9; obviously this won't work
            # concurrently, but it's not the default so...
            os.environ['DISPLAY'] = ':9'
        try:
            self.conn = self._connect_to_xvfb()
        except AssertionError:
>           self._restore_dislpay()
E           AttributeError: 'XcffibTest' object has no attribute '_restore_dislpay'

I ran mypy, and it doesn't seem to catch this one either, for some reason.
damn.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>