### PR TITLE
*: deep six "six"

### DIFF
--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -92,7 +92,7 @@ xform = map buildPython . dependencyOrder
     processXHeader :: XHeader
                    -> State TypeInfoMap (String, Suite ())
     processXHeader header = do
-      let imports = [mkImport "xcffib", mkImport "struct", mkImport "six"]
+      let imports = [mkImport "xcffib", mkImport "struct", mkImport "io"]
           version = mkVersion header
           key = maybeToList $ mkKey header
           globals = [mkDict "_events", mkDict "_errors"]
@@ -430,7 +430,7 @@ structElemToPyPack _ m accessor (ValueParam typ mask _ list) =
       "ValueParams other than CARD{16,32} not allowed.")
 
 buf :: Suite ()
-buf = [mkAssign "buf" (mkCall "six.BytesIO" noArgs)]
+buf = [mkAssign "buf" (mkCall "io.BytesIO" noArgs)]
 
 mkPackStmts :: String
             -> String

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flake8
 autopep8
-six
 cffi>=0.8.2

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ cffi_args = dict(
 )
 
 version = "0.12.1"
-dependencies = ['six', requires_cffi]
+dependencies = [requires_cffi]
 
 setup(
     name="xcffib",

--- a/test/generator/enum.py
+++ b/test/generator/enum.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class DeviceUse:

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
 key = xcffib.ExtensionKey("ERROR")
@@ -15,7 +15,7 @@ class RequestError(xcffib.Error):
         self.bad_value, self.minor_opcode, self.major_opcode = unpacker.unpack("xx2xIHBx")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 1))
         buf.write(struct.pack("=x2xIHBx", self.bad_value, self.minor_opcode, self.major_opcode))
         return buf.getvalue()

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 1
 MINOR_VERSION = 4
 key = xcffib.ExtensionKey("EVENT")
@@ -15,7 +15,7 @@ class ScreenChangeNotifyEvent(xcffib.Event):
         self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight = unpacker.unpack("xB2xIIIIHHHHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 0))
         buf.write(struct.pack("=B2xIIIIHHHHHH", self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight))
         buf_len = len(buf.getvalue())

--- a/test/generator/eventstruct.py
+++ b/test/generator/eventstruct.py
@@ -1,13 +1,13 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class EventForSend(xcffib.Buffer):
     pass
 class eventstructExtension(xcffib.Extension):
     def SendExtensionEvent(self, device_id, propagate, num_classes, num_events, events, classes, is_checked=False):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xBBHB3x", device_id, propagate, num_classes, num_events))
         buf.write(xcffib.pack_list(events, EventForSend))
         buf.write(xcffib.pack_list(classes, "B"))

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class KeymapNotifyEvent(xcffib.Event):
@@ -13,7 +13,7 @@ class KeymapNotifyEvent(xcffib.Event):
         self.keys = xcffib.List(unpacker, "B", 31)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", 11))
         buf.write(xcffib.pack_list(self.keys, "B"))
         buf_len = len(buf.getvalue())

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
@@ -15,7 +15,7 @@ class COLOR(xcffib.Struct):
         self.red, self.green, self.blue, self.alpha = unpacker.unpack("HHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=HHHH", self.red, self.green, self.blue, self.alpha))
         return buf.getvalue()
     fixed_size = 8
@@ -36,7 +36,7 @@ class RECTANGLE(xcffib.Struct):
         self.x, self.y, self.width, self.height = unpacker.unpack("hhHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=hhHH", self.x, self.y, self.width, self.height))
         return buf.getvalue()
     fixed_size = 8
@@ -50,7 +50,7 @@ class RECTANGLE(xcffib.Struct):
         return self
 class renderExtension(xcffib.Extension):
     def FillRectangles(self, op, dst, color, rects_len, rects, is_checked=False):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xB3xI", op, dst))
         buf.write(color.pack() if hasattr(color, "pack") else COLOR.synthetic(*color).pack())
         buf.write(xcffib.pack_list(rects, RECTANGLE))

--- a/test/generator/render_1.7.py
+++ b/test/generator/render_1.7.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")

--- a/test/generator/request.py
+++ b/test/generator/request.py
@@ -1,11 +1,11 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class requestExtension(xcffib.Extension):
     def CreateWindow(self, depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list, is_checked=False):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xBIIhhHHHHI", depth, wid, parent, x, y, width, height, border_width, _class, visual))
         buf.write(struct.pack("=I", value_mask))
         buf.write(xcffib.pack_list(value_list, "I"))

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class STR(xcffib.Struct):
@@ -13,7 +13,7 @@ class STR(xcffib.Struct):
         self.name = xcffib.List(unpacker, "c", self.name_len)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=B", self.name_len))
         buf.write(xcffib.pack_list(self.name, "c"))
         return buf.getvalue()
@@ -36,7 +36,7 @@ class ListExtensionsCookie(xcffib.Cookie):
     reply_type = ListExtensionsReply
 class request_replyExtension(xcffib.Extension):
     def ListExtensions(self, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2x"))
         return self.send_request(99, buf, ListExtensionsCookie, is_checked=is_checked)
 xcffib._add_ext(key, request_replyExtension, _events, _errors)

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class AxisInfo(xcffib.Struct):
@@ -12,7 +12,7 @@ class AxisInfo(xcffib.Struct):
         self.resolution, self.minimum, self.maximum = unpacker.unpack("Iii")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=Iii", self.resolution, self.minimum, self.maximum))
         return buf.getvalue()
     fixed_size = 12
@@ -33,7 +33,7 @@ class ValuatorInfo(xcffib.Struct):
         self.axes = xcffib.List(unpacker, AxisInfo, self.axes_len)
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=BBBBI", self.class_id, self.len, self.axes_len, self.mode, self.motion_size))
         buf.write(xcffib.pack_list(self.axes, AxisInfo))
         return buf.getvalue()

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class INT64(xcffib.Struct):
@@ -12,7 +12,7 @@ class INT64(xcffib.Struct):
         self.hi, self.lo = unpacker.unpack("iI")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=iI", self.hi, self.lo))
         return buf.getvalue()
     fixed_size = 8
@@ -60,7 +60,7 @@ class GetPropertyWithPadCookie(xcffib.Cookie):
     reply_type = GetPropertyWithPadReply
 class switchExtension(xcffib.Extension):
     def GetProperty(self, value_mask, items, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xI", value_mask))
         if value_mask & CA.Counter:
             counter = items.pop(0)
@@ -76,7 +76,7 @@ class switchExtension(xcffib.Extension):
             buf.write(struct.pack("=I", events))
         return self.send_request(59, buf, GetPropertyCookie, is_checked=is_checked)
     def GetPropertyWithPad(self, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2x"))
         return self.send_request(60, buf, GetPropertyWithPadCookie, is_checked=is_checked)
 xcffib._add_ext(key, switchExtension, _events, _errors)

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class CHARINFO(xcffib.Struct):
@@ -12,7 +12,7 @@ class CHARINFO(xcffib.Struct):
         self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes = unpacker.unpack("hhhhhH")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=hhhhhH", self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes))
         return buf.getvalue()
     fixed_size = 12
@@ -35,7 +35,7 @@ class FONTPROP(xcffib.Struct):
         self.name, self.value = unpacker.unpack("II")
         self.bufsize = unpacker.offset - base
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=II", self.name, self.value))
         return buf.getvalue()
     fixed_size = 8
@@ -66,7 +66,7 @@ class ListFontsWithInfoCookie(xcffib.Cookie):
     reply_type = ListFontsWithInfoReply
 class type_padExtension(xcffib.Extension):
     def ListFontsWithInfo(self, max_names, pattern_len, pattern, is_checked=True):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(struct.pack("=xx2xxHH", max_names, pattern_len))
         buf.write(xcffib.pack_list(pattern, "c"))
         return self.send_request(50, buf, ListFontsWithInfoCookie, is_checked=is_checked)

--- a/test/generator/union.py
+++ b/test/generator/union.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 _events = {}
 _errors = {}
 class ClientMessageData(xcffib.Union):
@@ -12,7 +12,7 @@ class ClientMessageData(xcffib.Union):
         self.data16 = xcffib.List(unpacker.copy(), "H", 10)
         self.data32 = xcffib.List(unpacker.copy(), "I", 5)
     def pack(self):
-        buf = six.BytesIO()
+        buf = io.BytesIO()
         buf.write(xcffib.pack_list(self.data8, "B"))
         return buf.getvalue()
 xcffib._add_ext(key, unionExtension, _events, _errors)

--- a/test/generator/xproto_1.7.py
+++ b/test/generator/xproto_1.7.py
@@ -1,6 +1,6 @@
 import xcffib
 import struct
-import six
+import io
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("XPROTO")

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import six
 import xcffib
 import xcffib.xproto
 
@@ -185,7 +184,7 @@ class TestConnection:
         utf8_string = xproto_test.intern("UTF8_STRING")
 
         title_bytes = b"test\xc2\xb7"
-        title_string = six.u("test\u00B7")
+        title_string = "test\u00B7"
 
         # First check with an object already encoded as bytes
         xproto_test.xproto.ChangeProperty(
@@ -297,12 +296,10 @@ class TestConnection:
         c.disconnect()
 
     def test_auth_connect(self, xproto_test):
-        authname = six.b("MIT-MAGIC-COOKIE-1")
-        authdata = six.b(
-            "\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47"
-        )
+        authname = b"MIT-MAGIC-COOKIE-1"
+        authdata = b"\xa5\xcf\x95\xfa\x19\x49\x03\x60\xaf\xe4\x1e\xcd\xa3\xe2\xad\x47"
 
-        authstr = authname + six.b(":") + authdata
+        authstr = authname + b":" + authdata
 
         conn = xcffib.connect(display=os.environ["DISPLAY"], auth=authstr)
 


### PR DESCRIPTION
We haven't supported python2 for a long time, so this is just a dependency we don't really need and which probably won't be available forever. Let's get rid of it.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>