### PR TITLE
don't generate invalid syntax on padding unpack

### DIFF
--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -488,7 +488,7 @@ mkPackStmts ext name m accessor prefix membs =
 
       mkBasePack (Nothing, "") = []
       mkBasePack (n, c) =
-        let n' = maybe "" id n
+        let n' = maybe "_" id n
         in [(n', Left (Just (mkCall "struct.pack" [mkStr ('=' : c), mkName n'])))]
 
 mkPackMethod :: String


### PR DESCRIPTION
Since we're ordering unpack requests now, we can sometimes unpack padding. This returns nothing, but it is easier in the generator code to assign it to "_" than to not make the assignment at all, so let's just do that.

Fixes: #144

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>