### PR TITLE
don't assign pack pop result to anything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,12 @@ htests:
 	$(CABAL) new-test -j$(NCPUS) --enable-tests
 
 check: xcffib lint htests
+	# lots of bugs here, so we keep the || true for now, but
+	# render all this just to be annoying so hopefully someone
+	# will fix these. they have all been around for a long time,
+	# so nobody is using the buggy requests right now,
+	# presumably.
+	flake8 -j$(NCPUS) --ignore=E128,E231,E251,E301,E302,E305,E501,F401,E402,W503,E741,E999 xcffib/*.py || true
 	pytest-3 -v --durations=3
 
 # make release ver=0.99.99

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ check: xcffib lint htests
 	# so nobody is using the buggy requests right now,
 	# presumably.
 	flake8 -j$(NCPUS) --ignore=E128,E231,E251,E301,E302,E305,E501,F401,E402,W503,E741,E999 xcffib/*.py || true
+	python3 -m compileall xcffib
 	pytest-3 -v --durations=3
 
 # make release ver=0.99.99

--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -484,11 +484,13 @@ mkPackStmts ext name m accessor prefix membs =
       mkPop :: String
             -> String
             -> Statement ()
-      mkPop toPop n = mkAssign n $ mkCall (mkDot toPop "pop") [mkInt 0]
+      mkPop toPop n =
+        let pop = mkCall (mkDot toPop "pop") [mkInt 0]
+        in if null n then StmtExpr pop () else mkAssign n pop
 
       mkBasePack (Nothing, "") = []
       mkBasePack (n, c) =
-        let n' = maybe "_" id n
+        let n' = maybe "" id n
         in [(n', Left (Just (mkCall "struct.pack" [mkStr ('=' : c), mkName n'])))]
 
 mkPackMethod :: String

--- a/test/generator/xinput.xml
+++ b/test/generator/xinput.xml
@@ -1,0 +1,82 @@
+<!-- a request with padding *after* a complex type -->
+<enum name="DeviceClassType">
+    <item name="Key">      <value>0</value> </item>
+    <item name="Button">   <value>1</value> </item>
+    <item name="Valuator"> <value>2</value> </item>
+    <item name="Scroll">   <value>3</value> </item>
+    <item name="Touch">    <value>8</value> </item>
+    <item name="Gesture">  <value>9</value> </item>
+</enum>
+
+<struct name="DeviceClass">
+    <length>
+        <op op="*">
+            <fieldref>len</fieldref>
+            <value>4</value>
+        </op>
+    </length>
+    <field type="CARD16"   name="type" enum="DeviceClassType" />
+    <field type="CARD16"   name="len" />
+    <field type="DeviceId" name="sourceid" />
+    <switch name="data">
+    <fieldref>type</fieldref>
+    <required_start_align align="4" offset="2" />
+    <case name="key">
+    <enumref ref="DeviceClassType">Key</enumref>
+    <required_start_align align="4" offset="2" />
+    <field type="CARD16"   name="num_keys" />
+    <list type="CARD32" name="keys">
+        <fieldref>num_keys</fieldref>
+    </list>
+    </case>
+    <case name="button">
+    <enumref ref="DeviceClassType">Button</enumref>
+    <required_start_align align="4" offset="2" />
+    <field type="CARD16"   name="num_buttons" />
+    <list type="CARD32"    name="state">
+        <op op="/">
+            <op op="+">
+                <fieldref>num_buttons</fieldref>
+                <value>31</value>
+            </op>
+            <value>32</value>
+        </op>
+    </list>
+    <list type="ATOM" name="labels">
+        <fieldref>num_buttons</fieldref>
+    </list>
+    </case>
+    <case name="valuator">
+    <enumref ref="DeviceClassType">Valuator</enumref>
+    <required_start_align align="4" offset="2" />
+    <field type="CARD16"   name="number" />
+    <field type="ATOM"     name="label" />
+    <field type="FP3232"   name="min" />
+    <field type="FP3232"   name="max" />
+    <field type="FP3232"   name="value" />
+    <field type="CARD32"   name="resolution" />
+    <field type="CARD8"    name="mode" enum="ValuatorMode" />
+    <pad bytes="3" />
+    </case>
+    <case name="scroll">
+    <enumref ref="DeviceClassType">Scroll</enumref>
+            <required_start_align align="4" offset="2" />
+    <field type="CARD16"   name="number" />
+    <field type="CARD16"   name="scroll_type" enum="ScrollType" />
+    <pad bytes="2" />
+    <field type="CARD32"   name="flags" mask="ScrollFlags" />
+    <field type="FP3232"   name="increment" />
+    </case>
+    <case name="touch">
+    <enumref ref="DeviceClassType">Touch</enumref>
+    <field type="CARD8"    name="mode" enum="TouchMode" />
+    <field type="CARD8"    name="num_touches" />
+    </case>
+    <case name="gesture">
+        <enumref ref="DeviceClassType">Gesture</enumref>
+        <field type="CARD8"    name="num_touches" />
+        <pad bytes="1" />
+    </case>
+</switch>
+</struct>
+


### PR DESCRIPTION
c94ea3e76b4a ("don't generate invalid syntax on padding unpack") caused some weird things to happen, e.g.:

    struct.pack("3x", _)

instead, let's just not assign the result of popping padding to anything, which was the source of the original syntax error.

This commit also adds a (failing) flake8 line to check the generated code. This line reveals other bugs, so we have to leave it fail for now. But these bugs have all been in xcffib for a long time, so it's probably ok :)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>