### PR TITLE
Fix `List.to_string()`

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -456,7 +456,10 @@ class List(Protobj):
         """ A helper for converting a List of chars to a native string. Dies if
         the list contents are not something that could be reasonably converted
         to a string. """
-        return ''.join(chr(i[0]) for i in self)
+        try:
+            return ''.join(chr(i[0]) for i in self)
+        except TypeError:
+            return ''.join(chr(i) for i in self)
 
     def to_utf8(self):
         return b''.join(self).decode('utf-8')

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -53,8 +53,8 @@ class TestConnection:
         # i.e:
         # xproto setup query = seqno 0
         # xtest setup query = seqno 1
-        assert xproto_test.xproto.GetInputFocus().sequence == 6
         assert xproto_test.xproto.GetInputFocus().sequence == 7
+        assert xproto_test.xproto.GetInputFocus().sequence == 8
 
     def test_discard_sequence(self, xproto_test):
         cookie = xproto_test.xproto.GetInputFocus()

--- a/test/test_python_code.py
+++ b/test/test_python_code.py
@@ -16,6 +16,7 @@
 import xcffib
 import xcffib.xproto
 import xcffib.xinput
+import xcffib.randr
 import os
 import struct
 import sys
@@ -185,6 +186,20 @@ class TestPythonCode:
         assert isinstance(event, xcffib.xinput.BarrierHitEvent)
         assert event.root_x >> 16 == 100
         assert event.root_y >> 16 == 200
+
+    def test_List_to_string(self, xcffib_test):
+        xrandr = xcffib_test.conn(xcffib.randr.key)
+        try:
+            setup = xcffib_test.conn.get_setup()
+            for screen in setup.roots:
+                scrn_rsrcs = xrandr.GetScreenResources(screen.root).reply()
+                for output in scrn_rsrcs.outputs:
+                    info = xrandr.GetOutputInfo(output, xcffib.XCB_CURRENT_TIME).reply()
+                    print(info.name.to_string())
+                    assert info.name.to_string() == 'screen'
+        finally:
+            xcffib_test.conn.disconnect()
+
 
 
 class TestXcffibTestGenerator:


### PR DESCRIPTION
Given this program as an example:

```python
import xcffib
import xcffib.randr
import xcffib.xproto

xconn = xcffib.Connection()
xrandr = xconn(xcffib.randr.key)
try:
	setup = xconn.get_setup()
	for screen in setup.roots:
		scrn_rsrcs = xrandr.GetScreenResources(screen.root).reply()
		for output in scrn_rsrcs.outputs:
			info = xrandr.GetOutputInfo(output, xcffib.XCB_CURRENT_TIME).reply()
			print(info.name.to_string())
finally:
	xconn.disconnect()
```

A `TypeError: 'int' object is not subscriptable` error is thrown.  With this patch it prints the name of each output as expected:

```
eDP-1
DP-1
DP-2
DP-3
DP-4
```