### PR TITLE
build against xcb-proto 1.16.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [3.8, 3.9, "3.10", "3.11", "pypy3.9"]
-                xcbver: [xcb-proto-1.14.1, xcb-proto-1.15.2, master]
+                xcbver: [xcb-proto-1.14.1, xcb-proto-1.15.2, xcb-proto-1.16.0, master]
         steps:
             - uses: actions/checkout@v3
             - name: Set up python "${{ matrix.python-version }}"

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,18 @@ lint:
 htests:
 	$(CABAL) new-test -j$(NCPUS) --enable-tests
 
+# The --builtin=CW is a hack to work around:
+# https://lists.freedesktop.org/archives/xcb/2022-December/011427.html
+# when that lands and all tested versions have it, we can
+# drop this.
+#
+# In the meantime, we can work around this in the binding if someone really needs it.
+ifeq ($(shell printf "$(XCBVER)\n1.16.0" | sort -V | grep -c 1.16.0), 1)
+CW_HACK=--builtins=CW
+endif
+
 check: xcffib lint htests
-	# The --builtin=CW is a hack to work around:
-	# https://lists.freedesktop.org/archives/xcb/2022-December/011427.html
-	# when that lands and all tested versions have it, we can
-	# drop this.
-	#
-	# In the meantime, we can work around this in the binding if someone really needs it.
-	flake8 -j$(NCPUS) --ignore=E128,E231,E251,E301,E302,E305,E501,F401,E402,W503,E741,E999 xcffib/*.py --builtins=CW
+	flake8 -j$(NCPUS) --ignore=E128,E231,E251,E301,E302,E305,E501,F401,E402,W503,E741,E999 xcffib/*.py $(CW_HACK)
 	python3 -m compileall xcffib
 	pytest-3 -v --durations=3
 


### PR DESCRIPTION
We can finally get rid of the --builtins=CW hack (for certain versions...)! I will probably do a release soon to capture this. But let's at least run some CI against it for now.