### PR TITLE
do not depend on cffi for PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,15 +43,8 @@ class binding_install(install):
             sys.exit(1)
         install.finalize_options(self)
 
-# Check if we're running PyPy, cffi can't be updated
-if '_cffi_backend' in sys.builtin_module_names:
-    import _cffi_backend
-    requires_cffi = "cffi==" + _cffi_backend.__version__
-else:
-    requires_cffi = "cffi>=1.1.0"
-
 version = "1.5.0"
-dependencies = [requires_cffi]
+dependencies = ["cffi>=1.1.0; python_implementation != 'PyPy'"]
 
 setup(
     name="xcffib",


### PR DESCRIPTION
Make the dependency on `cffi` conditional to non-PyPy interpreters, in order to make the package installable on modern PyPy versions and ensure that the wheel metadata is static, irrespectively of which Python implementation is used to build it.  The previous hack would attempt to install exactly the same `cffi` version that was used on PyPy which in the best case was redundant, and in the worst case made the package non-installable if PyPy used a non-public `cffi` version.

Fixes #166