### PR TITLE
generator: drop dependency on language-python

### DIFF
--- a/generator/Data/XCB/Python/AST.hs
+++ b/generator/Data/XCB/Python/AST.hs
@@ -1,0 +1,232 @@
+{-
+ - Copyright 2024 Tycho Andersen
+ -
+ - This module exists as a small AST to replace language-python, which seems
+ - largely unmaintained at this point. This is not really intended to be a
+ - complete python grammer, mostly it is just enough to be what xcffib needs to
+ - generate its trees.
+ -
+ - It has no annotations as in language-python, because xcffib doesn't use them.
+ -
+ - The grammar not complete: it cannot express anything other than empty
+ - dictionaries, cannot express sets at all, cannot do async, etc. all because
+ - these features of the language are unused by xcffib.
+ -
+ - The grammar is not sound: it has one "op" class, representing both unary and
+ - binary operators.
+ -
+ - Use at your own risk :)
+ -}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Data.XCB.Python.AST (
+  Expr(..),
+  Suite,
+  Statement(..),
+  Ident,
+  Op(..),
+  Pretty(..),
+  prettyText,
+  PseudoExpr(..)
+) where
+
+import Prelude hiding ((<>))
+
+import Data.Maybe
+
+import Text.PrettyPrint
+
+type Suite = [Statement]
+
+type Ident = String
+
+-- we don't use that many operations :)
+data Op
+   = Plus
+   | Minus
+   | Multiply
+   | FloorDivide
+   | BinaryAnd
+   | ShiftRight
+   | ShiftLeft
+   | Invert
+   | Equality
+   | LessThan
+   deriving (Eq, Ord, Show)
+
+data Statement
+    = Import
+      { import_item :: Ident }
+    -- this is only a one level dotted import; other levels are not supported
+    | FromImport
+      { from_module :: Ident
+      , from_item :: Ident
+      }
+    -- we skip While, For, AsyncFor, etc. because we don't use them
+    | Fun
+      { fun_name :: Ident
+      -- only named variables, no default values, kwargs, etc.
+      , fun_args :: [Ident]
+      , fun_body :: Suite
+      }
+    | Decorated
+      { decorations :: Ident
+      -- only decorated functions/methods are supported
+      , fun_name :: Ident
+      , fun_args :: [Ident]
+      , fun_body :: Suite
+      }
+    -- skip AsyncFun...
+    | Class
+      { class_name :: Ident
+      -- same as functions, only identifiers allowed
+      , class_args :: [Ident]
+      , class_body :: Suite
+      }
+    | Conditional
+      { if_cond :: Expr
+      , if_body :: Suite
+      , else_body :: Suite
+      }
+    | Assign
+      { assign_to :: Expr
+      , assign_expr :: Expr
+      }
+    | AugmentedAssign
+      { aug_assign_to :: Expr
+      , aug_assign_op :: Op
+      , aug_assign_expr :: Expr
+      }
+    -- skip AnnotatedAssign, Decorated
+    | Return
+      { return_expr :: Maybe (Expr) }
+    -- skip Try, Raise, With, AsyncWith
+    | Pass {}
+    -- skip Break, Continue, Delete
+    | StmtExpr
+      { stmt_expr :: Expr }
+    -- skip Global, NonLocal, Assert, Print, Exec
+    deriving (Eq, Ord, Show)
+
+data Expr
+    = Var { var :: Ident }
+    | Int { int_value :: Integer }
+    | Bool { bool_value :: Bool }
+    | None
+    | Strings { strings_strings :: [String] }
+    | Call
+      { call_fun :: Expr
+      , call_args :: [Expr]
+      }
+    | CondExpr
+      { ce_true_branch :: Expr
+      , ce_conditon :: Expr
+      , ce_false_branch :: Expr
+      }
+    | Subscript
+      { subscriptee :: Expr
+      , subscript_expr :: Expr
+      }
+    | BinaryOp
+      { operator :: Op
+      , binop_left :: Expr
+      , binop_right :: Expr
+      }
+    | UnaryOp
+      { operator :: Op
+      , unop_arg :: Expr
+      }
+    | Dot
+      { dot_expr :: Expr
+      , dot_attribute :: Ident
+      }
+    | Tuple { tuple_exprs :: [Expr] }
+    | EmptyDict {} -- an empty dictionary
+    | Paren { paren_expr :: Expr }
+    deriving (Eq, Ord, Show)
+
+prettyText :: Pretty a => a -> String
+prettyText = render . pretty
+
+class Pretty a where
+    pretty :: a -> Doc
+
+instance Pretty Op where
+    pretty Plus = text "+"
+    pretty Minus = text "-"
+    pretty Multiply = text "*"
+    pretty FloorDivide = text "//"
+    pretty BinaryAnd = text "&"
+    pretty ShiftRight = text ">>"
+    pretty ShiftLeft = text "<<"
+    pretty Invert = text "~"
+    pretty Equality = text "=="
+    pretty LessThan = text "<"
+
+_reserved :: [String]
+_reserved = [ "None"
+            , "def"
+            , "class"
+            , "and"
+            , "or"
+            ]
+
+-- | Sanitize identifiers.
+instance Pretty Ident where
+    pretty s | s `elem` _reserved = text $ "_" ++ s
+    pretty s | isInt s = text $ "_" ++ s
+      where
+        isInt str = isJust $ ((maybeRead str) :: Maybe Int)
+        maybeRead = fmap fst . listToMaybe . reads
+    pretty s = text s
+
+instance Pretty Suite where
+    pretty stmts = vcat $ map pretty stmts
+
+indent :: Doc -> Doc
+indent = nest 4
+
+instance Pretty Statement where
+    pretty (Import item) = text "import" <+> pretty item
+    pretty (FromImport source item) = text "from" <+> text source <+> text "import" <+> pretty item
+    pretty (Fun name args bod) = text "def" <+> pretty name <> (parens (addCommas args)) <> colon
+                                 $+$ indent (pretty bod)
+    pretty (Decorated decorator name args bod) = text "@" <> text decorator $+$ pretty (Fun name args bod)
+    pretty (Class name [] body) = text "class" <+> pretty name <> colon $+$ indent (pretty body)
+    pretty (Class name superclasses body) = text "class" <+> pretty name <> parens (addCommas superclasses) <> colon $+$ indent (pretty body)
+    pretty (Conditional cond if_ else_) = text "if" <+> pretty cond <> colon $+$ indent (pretty if_) $+$ pretty else_
+    pretty (Assign to expr) = pretty to <+> text "=" <+> pretty expr
+    pretty (AugmentedAssign to op expr) = pretty to <+> pretty op <> text "=" <+> pretty expr
+    pretty (Return (Just expr)) = text "return" <+> pretty expr
+    pretty (Return Nothing) = text "return"
+    pretty Pass = text "pass"
+    pretty (StmtExpr expr) = pretty expr
+
+class PseudoExpr a where
+  getExpr :: a -> Expr
+
+instance PseudoExpr String where
+  getExpr s = Var s
+instance PseudoExpr Expr where
+  getExpr = id
+
+addCommas :: PseudoExpr a => [a] -> Doc
+addCommas exprs = hsep $ punctuate (text ",") (map (pretty . getExpr) exprs)
+
+instance Pretty Expr where
+    pretty (Var v) = pretty v
+    pretty (Int i) = integer i
+    pretty (Bool True) = text "True"
+    pretty (Bool False) = text "False"
+    pretty None = text "None"
+    pretty (Strings xs) = hcat (map text xs)
+    pretty (Call fun args) = pretty fun <> lparen <> addCommas args <> rparen
+    pretty (CondExpr trueB cond falseB) = pretty trueB <+> text "if" <+> pretty cond <+> text "else" <+> pretty falseB
+    pretty (Subscript thing expr) = pretty thing <> brackets (pretty expr)
+    pretty (BinaryOp op left right) = pretty left <+> pretty op <+> pretty right
+    pretty (UnaryOp op arg) = pretty op <> pretty arg
+    pretty (Dot thing attr) = pretty thing <> text "." <> pretty attr
+    pretty (Tuple [expr]) = pretty expr <> comma -- one element still needs to be a tuple
+    pretty (Tuple exprs) = addCommas exprs
+    pretty EmptyDict = text "{}"
+    pretty (Paren expr) = lparen <> pretty expr <> rparen

--- a/test/GeneratorTests.hs
+++ b/test/GeneratorTests.hs
@@ -15,8 +15,7 @@
  -}
 module Main (main) where
 
-import Language.Python.Common
-
+import Data.XCB.Python.AST
 import Data.XCB.Python.Parse
 import Data.XCB.FromXML
 import Data.XCB.Types

--- a/test/PyHelpersTests.hs
+++ b/test/PyHelpersTests.hs
@@ -15,9 +15,8 @@
  -}
 module Main (main) where
 
-import Language.Python.Common
-
 import Data.XCB.Python.PyHelpers
+import Data.XCB.Python.AST
 
 import Test.Framework ( defaultMain, Test )
 import Test.Framework.Providers.HUnit
@@ -29,15 +28,15 @@ mkTest name t1 t2 = testCase name (assertEqual name t1 t2)
 testMkName :: Test
 testMkName =
   let result = mkName "self.foo.bar"
-      expected = (Dot (Dot (Var (Ident "self" ()) ())
-                           (Ident "foo" ()) ())
-                      (Ident "bar" ()) ())
+      expected = (Dot (Dot (Var "self")
+                           "foo")
+                      "bar")
   in mkTest "testMkName" expected result
 
 testReserves :: Test
 testReserves =
-  let result = mkName "None"
-      expected = (Var (Ident "_None" ()) ())
+  let result = prettyText (mkName "None")
+      expected = "_None"
   in mkTest "testReserves" expected result
 
 main :: IO ()

--- a/xcffib.cabal
+++ b/xcffib.cabal
@@ -26,7 +26,6 @@ source-repository head
 library
   build-depends: base ==4.*,
                  xcb-types >= 0.14.0 && < 0.15,
-                 language-python >= 0.5.8 && < 0.6,
                  filepath >= 1.4.2 && < 1.5,
                  filemanip >= 0.3.6 && < 0.4,
                  split >= 0.2.3 && < 0.3,
@@ -34,10 +33,12 @@ library
                  mtl >= 2.2.2 && < 2.4,
                  attoparsec >= 0.14.4 && < 0.15,
                  bytestring >= 0.11.3 && < 0.12,
-                 either >= 5.0.2 && < 5.1
+                 either >= 5.0.2 && < 5.1,
+                 pretty >= 1.1 && < 1.2
   hs-source-dirs: generator
   exposed-modules: Data.XCB.Python.Parse,
                    Data.XCB.Python.PyHelpers
+                   Data.XCB.Python.AST
   ghc-options: -Wall
   default-language: Haskell2010
 
@@ -47,7 +48,6 @@ executable xcffibgen
   build-depends: base ==4.*,
                  xcffib,
                  xcb-types >= 0.14.0 && < 0.15,
-                 language-python >= 0.5.8 && < 0.6,
                  filepath >= 1.4.2 && < 1.5,
                  filemanip >= 0.3.6 && < 0.4,
                  split >= 0.2.3 && < 0.3,
@@ -56,10 +56,12 @@ executable xcffibgen
                  attoparsec >= 0.14.4 && < 0.15,
                  bytestring >= 0.11.3 && < 0.12,
                  either >= 5.0.2 && < 5.1,
+                 pretty >= 1.1 && < 1.2,
                  directory >= 1.3.6 && < 1.4,
                  optparse-applicative >= 0.18.1 && < 0.19
   other-modules: Data.XCB.Python.Parse,
                  Data.XCB.Python.PyHelpers
+                 Data.XCB.Python.AST
   ghc-options: -Wall
   default-language: Haskell2010
 
@@ -69,7 +71,6 @@ test-suite PyHelpersTests
   type: exitcode-stdio-1.0
   build-depends: base ==4.*,
                  xcffib,
-                 language-python >= 0.5.8 && < 0.6,
                  HUnit >= 1.6.2 && < 1.7,
                  test-framework >= 0.8.2 && < 0.9,
                  test-framework-hunit >= 0.3.0 && < 0.4
@@ -82,7 +83,6 @@ test-suite GeneratorTests.hs
   build-depends: base ==4.*,
                  xcffib,
                  xcb-types >= 0.14.0 && < 0.15,
-                 language-python >= 0.5.8 && < 0.6,
                  filepath >= 1.4.2 && < 1.5,
                  HUnit >= 1.6.2 && < 1.7,
                  test-framework >= 0.8.2 && < 0.9,


### PR DESCRIPTION
language-python seems largely unmaintained at this point. Its last release
was over four years ago, and our CI has not passed for the last five months
due to this problem, and we have been unable to release fixes, etc. as a
result.

So, let's move away from language-python. Obviously reinventing the python
grammar+pretty printer is a pain, but we don't use that much of it, and it
only took me a few evenings to get all the tests passing and the diff to
basically zero (see below).

This has several advantages:

1. we get rid of lots of () noise, since we didn't use annotations
2. a lot of the helpers are simplified since we are much less flexible
3. much faster build time than language-python

This doesn't do as much simplification as possible, probably more to come.

Here is the total diff with the current released version of xcffib, which
is basically just binary not getting less ugly, and our placeholder.

    ~/.local/lib/python3.10/site-packages/xcffib for i in *py; do diff -U5 ./$i ~/packages/xcffib/xcffib/$i; done
    --- ./dri2.py	2024-01-21 16:18:07.499919937 -0700
    +++ /home/tycho/packages/xcffib/xcffib/dri2.py	2024-12-03 21:01:32.943608482 -0700
    @@ -88,11 +88,11 @@
             xcffib.Reply.__init__(self, unpacker)
             base = unpacker.offset
             self.driver_name_length, self.device_name_length = unpacker.unpack("xx2x4xII16x")
             self.driver_name = xcffib.List(unpacker, "c", self.driver_name_length)
             unpacker.pad("c")
    -        self.alignment_pad = xcffib.List(unpacker, "c", ((self.driver_name_length + 3) & (~ 3)) - self.driver_name_length)
    +        self.alignment_pad = xcffib.List(unpacker, "c", ((self.driver_name_length + 3) & (~3)) - self.driver_name_length)
             unpacker.pad("c")
             self.device_name = xcffib.List(unpacker, "c", self.device_name_length)
             self.bufsize = unpacker.offset - base
     class ConnectCookie(xcffib.Cookie):
         reply_type = ConnectReply
    --- ./__init__.py	2024-01-21 16:18:07.499919937 -0700
    +++ /home/tycho/packages/xcffib/xcffib/__init__.py	2024-12-03 21:01:33.083611579 -0700
    @@ -33,11 +33,11 @@
         if soname is None:
             soname = "libxcb.so"
     lib = ffi.dlopen(soname)

     __xcb_proto_version__ = "1.16.0"
    -__version__ = "1.5.0"
    +__version__ = 'placeholder'

     X_PROTOCOL = lib.X_PROTOCOL
     X_PROTOCOL_REVISION = lib.X_PROTOCOL_REVISION

     XCB_NONE = lib.XCB_NONE
    --- ./xf86vidmode.py	2024-01-21 16:18:07.499919937 -0700
    +++ /home/tycho/packages/xcffib/xcffib/xf86vidmode.py	2024-12-03 21:01:33.039610605 -0700
    @@ -90,11 +90,11 @@
             unpacker.pad("I")
             self.vsync = xcffib.List(unpacker, "I", self.num_vsync)
             unpacker.pad("c")
             self.vendor = xcffib.List(unpacker, "c", self.vendor_length)
             unpacker.pad("c")
    -        self.alignment_pad = xcffib.List(unpacker, "c", ((self.vendor_length + 3) & (~ 3)) - self.vendor_length)
    +        self.alignment_pad = xcffib.List(unpacker, "c", ((self.vendor_length + 3) & (~3)) - self.vendor_length)
             unpacker.pad("c")
             self.model = xcffib.List(unpacker, "c", self.model_length)
             self.bufsize = unpacker.offset - base
     class GetMonitorCookie(xcffib.Cookie):
         reply_type = GetMonitorReply
    @@ -161,15 +161,15 @@
             if isinstance(unpacker, xcffib.Protobj):
                 unpacker = xcffib.MemoryUnpacker(unpacker.pack())
             xcffib.Reply.__init__(self, unpacker)
             base = unpacker.offset
             self.size, = unpacker.unpack("xx2x4xH22x")
    -        self.red = xcffib.List(unpacker, "H", (self.size + 1) & (~ 1))
    +        self.red = xcffib.List(unpacker, "H", (self.size + 1) & (~1))
             unpacker.pad("H")
    -        self.green = xcffib.List(unpacker, "H", (self.size + 1) & (~ 1))
    +        self.green = xcffib.List(unpacker, "H", (self.size + 1) & (~1))
             unpacker.pad("H")
    -        self.blue = xcffib.List(unpacker, "H", (self.size + 1) & (~ 1))
    +        self.blue = xcffib.List(unpacker, "H", (self.size + 1) & (~1))
             self.bufsize = unpacker.offset - base
     class GetGammaRampCookie(xcffib.Cookie):
         reply_type = GetGammaRampReply
     class GetGammaRampSizeReply(xcffib.Reply):
         xge = False