### PR TITLE
ci: always use $PATH python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
               with:
                   ghc-version: '9.6'
                   cabal-version: latest
-            - run: cabal update
-            - run: sudo apt install x11-apps python3-pytest python3-cffi python3-pytest-xdist flake8
+            - run: sudo apt install x11-apps
             - run: git clone https://gitlab.freedesktop.org/xorg/proto/xcbproto.git proto && cd proto && git checkout ${{ matrix.xcbver }}
             - run: make XCBDIR=./proto/src check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
                   cabal-version: latest
             - run: sudo apt install x11-apps
             - run: git clone https://gitlab.freedesktop.org/xorg/proto/xcbproto.git proto && cd proto && git checkout ${{ matrix.xcbver }}
-            - run: make XCBDIR=./proto/src check
+            - run: make -j XCBDIR=./proto/src check

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist-newstyle
 *__pycache__*
 *.egg-info
 xcffib
+xcffib_venv
 build/
 *egg*
 *deb

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 endif
 NCPUS=$(shell grep -c processor /proc/cpuinfo)
 PARALLEL=$(shell which parallel)
-CABAL=cabal --config-file=./cabal.config
+CABAL=flock xcffib.cabal cabal --config-file=./cabal.config
 GEN=$(CABAL) new-run --minimize-conflict-set -j$(NCPUS) exe:xcffibgen --
 VENV=xcffib_venv
 PYTHON=$(VENV)/bin/python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 flake8
 autopep8
 cffi>=0.8.2
+pytest
+pytest-xdist
+cffi >= 1.6


### PR DESCRIPTION
Consider the following output form `which python3` and `which pytest-3` in the CI environment:

    which python3
    shell: /usr/bin/bash -e {0}
    env:
        pythonLocation: /opt/hostedtoolcache/Python/3.10.15/x64
        PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.15/x64/lib/pkgconfig
        Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.15/x64/lib
    /opt/hostedtoolcache/Python/3.10.15/x64/bin/python3

    which pytest-3
    shell: /usr/bin/bash -e {0}
    env:
        pythonLocation: /opt/hostedtoolcache/Python/3.10.15/x64
        PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.15/x64/lib/pkgconfig
        Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.15/x64
        LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.15/x64/lib
    /usr/bin/pytest-3

Since we were getting e.g. cffi vi `apt-get install python3-cffi`, we were using the *system* python's cffi for everything. That worked because we invoked the *system* pytest-3.

Of course, that means we were not really using the github python action's python in our CI matrix, since we were always using the system python for everything.

Instead, let's set up a venv as a traditional project would, and that way we can explicitly call that venv's python everywhere in the makefile, so we always use that venv's packages and get the right python.

Then, we need only be careful to use the $PATH python, not /usr/bin/python, to set up this venv, and we always get the right version of python to test with.

This likely explains some weirdness that I've seen in the past, should have investigated sooner...