### PR TITLE
*: use ruff linting/formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: "${{ matrix.python-version }}"
+            - uses: astral-sh/ruff-action@v3
+              with:
+                  args: "check --exclude ./test/generator/"
             - uses: haskell-actions/setup@v2
               with:
                   ghc-version: '9.6'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
                   cabal-version: latest
             - run: sudo apt install x11-apps
             - run: git clone https://gitlab.freedesktop.org/xorg/proto/xcbproto.git proto && cd proto && git checkout ${{ matrix.xcbver }}
-            - run: make -j XCBDIR=./proto/src check
+            - run: make XCBDIR=./proto/src check

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-AUTOPEP8=autopep8 --in-place --aggressive --aggressive
-
 XCBDIR?=$(shell pkg-config --variable=xcbincludedir xcb-proto)
 ifneq ($(XCBDIR),$(shell pkg-config --variable=xcbincludedir xcb-proto))
 	XCBVER=$(shell sed -e '1,/AC_INIT/d' $(XCBDIR)/../configure.ac | head -n 1 | tr -d ,[:blank:])
@@ -7,27 +5,20 @@ else
 	XCBVER=$(shell pkg-config --modversion xcb-proto)
 endif
 NCPUS=$(shell grep -c processor /proc/cpuinfo)
-PARALLEL=$(shell which parallel)
 CABAL=flock xcffib.cabal cabal
 GEN=$(CABAL) new-run --minimize-conflict-set -j$(NCPUS) exe:xcffibgen --
 VENV=xcffib_venv
 PYTHON=$(VENV)/bin/python3
-FLAKE=$(VENV)/bin/flake8
+
+GENERATED_TESTS_DIR=./test/generator/
 
 # you should have xcb-proto installed to run this
 xcffib: module/*.py xcffib.cabal $(shell find . -path ./test -prune -false -o -name \*.hs)
 	$(GEN) --input $(XCBDIR) --output ./xcffib
+	ruff format ./xcffib
 	cp ./module/*py ./xcffib/
 	touch ./xcffib/py.typed
 	sed -i "s/__xcb_proto_version__ = .*/__xcb_proto_version__ = \"${XCBVER}\"/" xcffib/__init__.py
-
-.PHONY: xcffib-fmt
-xcffib-fmt: module/*.py
-ifeq (${PARALLEL},)
-	$(AUTOPEP8) ./xcffib/*.py
-else
-	find ./xcffib/*.py | parallel -j $(NCPUS) $(AUTOPEP8) '{}'
-endif
 
 dist-newstyle:
 	$(CABAL) new-configure --enable-tests
@@ -49,13 +40,15 @@ valgrind: xcffib
 	valgrind --leak-check=full --show-leak-kinds=definite pytest-3 -v
 
 newtests:
-	$(GEN) --input ./test/generator/ --output ./test/generator/
+	$(GEN) --input $(GENERATED_TESTS_DIR) --output $(GENERATED_TESTS_DIR)
 	git diff test
 
 # These are all split out so make -j3 check goes as fast as possible.
 .PHONY: lint
 lint: $(VENV)
-	$(FLAKE) --config=./test/flake8.cfg ./module
+	ruff check --exclude $(GENERATED_TESTS_DIR) --exclude ./proto
+	$(CABAL) check
+	$(PYTHON) -m compileall xcffib
 
 .PHONY: htests
 htests:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xcffib [![Build Status](https://github.com/tych0/xcffib/workflows/ci/badge.svg)](https://github.com/tych0/xcffib/actions)
+# xcffib [![Build Status](https://github.com/tych0/xcffib/workflows/ci/badge.svg?branch=master)](https://github.com/tych0/xcffib/actions)
 
 `xcffib` is the XCB binding for Python.
 

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -34,8 +34,8 @@ else:
         soname = "libxcb.so"
 lib = ffi.dlopen(soname)
 
-__xcb_proto_version__ = 'placeholder'
-__version__ = 'placeholder'
+__xcb_proto_version__ = "placeholder"
+__version__ = "placeholder"
 
 X_PROTOCOL = lib.X_PROTOCOL
 X_PROTOCOL_REVISION = lib.X_PROTOCOL_REVISION
@@ -83,7 +83,6 @@ def visualtype_to_c_struct(vt):
 
 
 class Unpacker(object):
-
     def __init__(self, known_max=None):
         self.size = 0
         self.offset = 0
@@ -131,7 +130,6 @@ class Unpacker(object):
 
 
 class CffiUnpacker(Unpacker):
-
     def __init__(self, cdata, known_max=None):
         self.cdata = cdata
         Unpacker.__init__(self, known_max)
@@ -151,7 +149,6 @@ class CffiUnpacker(Unpacker):
 
 
 class MemoryUnpacker(Unpacker):
-
     def __init__(self, buf):
         self.buf = buf
         Unpacker.__init__(self, len(self.buf))
@@ -169,12 +166,12 @@ class MemoryUnpacker(Unpacker):
 
 
 def popcount(n):
-    return bin(n).count('1')
+    return bin(n).count("1")
 
 
 class XcffibException(Exception):
+    """Generic XcbException; replaces xcb.Exception."""
 
-    """ Generic XcbException; replaces xcb.Exception. """
     pass
 
 
@@ -185,28 +182,33 @@ class XcffibNotImplemented(XcffibException, NotImplementedError):
 class ConnectionException(XcffibException):
     REASONS = {
         lib.XCB_CONN_ERROR: (
-            'xcb connection errors because of socket, '
-            'pipe and other stream errors.'),
+            "xcb connection errors because of socket, pipe and other stream errors."
+        ),
         lib.XCB_CONN_CLOSED_EXT_NOTSUPPORTED: (
-            'xcb connection shutdown because extension not supported'),
+            "xcb connection shutdown because extension not supported"
+        ),
         lib.XCB_CONN_CLOSED_MEM_INSUFFICIENT: (
-            'malloc(), calloc() and realloc() error upon failure, '
-            'for eg ENOMEM'),
+            "malloc(), calloc() and realloc() error upon failure, for eg ENOMEM"
+        ),
         lib.XCB_CONN_CLOSED_REQ_LEN_EXCEED: (
-            'Connection closed, exceeding request length that server '
-            'accepts.'),
+            "Connection closed, exceeding request length that server accepts."
+        ),
         lib.XCB_CONN_CLOSED_PARSE_ERR: (
-            'Connection closed, error during parsing display string.'),
+            "Connection closed, error during parsing display string."
+        ),
         lib.XCB_CONN_CLOSED_INVALID_SCREEN: (
-            'Connection closed because the server does not have a screen '
-            'matching the display.'),
+            "Connection closed because the server does not have a screen "
+            "matching the display."
+        ),
         lib.XCB_CONN_CLOSED_FDPASSING_FAILED: (
-            'Connection closed because some FD passing operation failed'),
+            "Connection closed because some FD passing operation failed"
+        ),
     }
 
     def __init__(self, err):
         XcffibException.__init__(
-            self, self.REASONS.get(err, "Unknown connection error."))
+            self, self.REASONS.get(err, "Unknown connection error.")
+        )
 
 
 class ProtocolException(XcffibException):
@@ -229,8 +231,7 @@ extensions = {}
 
 def _add_core(value, __setup, events, errors):
     if not issubclass(value, Extension):
-        raise XcffibException(
-            "Extension type not derived from xcffib.Extension")
+        raise XcffibException("Extension type not derived from xcffib.Extension")
     if not issubclass(__setup, Struct):
         raise XcffibException("Setup type not derived from xcffib.Struct")
 
@@ -247,14 +248,12 @@ def _add_core(value, __setup, events, errors):
 
 def _add_ext(key, value, events, errors):
     if not issubclass(value, Extension):
-        raise XcffibException(
-            "Extension type not derived from xcffib.Extension")
+        raise XcffibException("Extension type not derived from xcffib.Extension")
     extensions[key] = (value, events, errors)
 
 
 class ExtensionKey(object):
-
-    """ This definitely isn't needed, but we keep it around for compatibility
+    """This definitely isn't needed, but we keep it around for compatibility
     with xpyb.
     """
 
@@ -272,7 +271,7 @@ class ExtensionKey(object):
 
     def to_cffi(self):
         c_key = ffi.new("struct xcb_extension_t *")
-        c_key.name = name = ffi.new('char[]', self.name.encode())
+        c_key.name = name = ffi.new("char[]", self.name.encode())
         cffi_explicit_lifetimes[c_key] = name
         # xpyb doesn't ever set global_id, which seems wrong, but whatever.
         c_key.global_id = 0
@@ -281,8 +280,7 @@ class ExtensionKey(object):
 
 
 class Protobj(object):
-
-    """ Note: Unlike xcb.Protobj, this does NOT implement the sequence
+    """Note: Unlike xcb.Protobj, this does NOT implement the sequence
     protocol. I found this behavior confusing: Protobj would implement the
     sequence protocol on self.buf, and then List would go and implement it on
     List.
@@ -337,7 +335,8 @@ class Cookie(object):
     def check(self):
         # Request is not void and checked.
         assert self.is_checked and self.reply_type is None, (
-            "Request is not void and checked")
+            "Request is not void and checked"
+        )
         self.conn.request_check(self.sequence)
 
     def discard_reply(self):
@@ -345,13 +344,11 @@ class Cookie(object):
 
 
 class VoidCookie(Cookie):
-
     def reply(self):
         raise XcffibException("No reply for this message type")
 
 
 class Extension(object):
-
     def __init__(self, conn, key=None):
         self.conn = conn
 
@@ -362,8 +359,9 @@ class Extension(object):
             cffi_explicit_lifetimes[self] = c_key
             self.c_key = c_key
 
-    def send_request(self, opcode, data, cookie=VoidCookie, reply=None,
-                     is_checked=False):
+    def send_request(
+        self, opcode, data, cookie=VoidCookie, reply=None, is_checked=False
+    ):
         data = data.getvalue()
 
         assert len(data) > 3, "xcb_send_request data must be ast least 4 bytes"
@@ -383,7 +381,7 @@ class Extension(object):
 
         # Here we need this iov_base to keep this memory alive until the end of
         # the function.
-        xcb_parts[2].iov_base = iov_base = ffi.new('char[]', data)  # noqa
+        xcb_parts[2].iov_base = iov_base = ffi.new("char[]", data)  # noqa
         xcb_parts[2].iov_len = len(data)
         xcb_parts[3].iov_base = ffi.NULL
         xcb_parts[3].iov_len = -len(data) & 3  # is this really necessary?
@@ -396,10 +394,10 @@ class Extension(object):
 
     def __getattr__(self, name):
         if name.endswith("Checked"):
-            real = name[:-len("Checked")]
+            real = name[: -len("Checked")]
             is_checked = True
         elif name.endswith("Unchecked"):
-            real = name[:-len("Unchecked")]
+            real = name[: -len("Unchecked")]
             is_checked = False
         else:
             raise AttributeError(name)
@@ -410,7 +408,6 @@ class Extension(object):
 
 
 class List(Protobj):
-
     def __init__(self, unpacker, typ, count=None):
         Protobj.__init__(self, unpacker)
 
@@ -431,7 +428,7 @@ class List(Protobj):
 
         self.bufsize = unpacker.offset - old
 
-        self.raw = bytes(unpacker.buf[old:old + self.bufsize])
+        self.raw = bytes(unpacker.buf[old : old + self.bufsize])
 
         assert count is None or count == len(self.list)
 
@@ -454,25 +451,25 @@ class List(Protobj):
         del self.list[key]
 
     def to_string(self):
-        """ A helper for converting a List of chars to a native string. Dies if
+        """A helper for converting a List of chars to a native string. Dies if
         the list contents are not something that could be reasonably converted
-        to a string. """
+        to a string."""
         try:
-            return ''.join(chr(i[0]) for i in self)
+            return "".join(chr(i[0]) for i in self)
         except TypeError:
-            return ''.join(chr(i) for i in self)
+            return "".join(chr(i) for i in self)
 
     def to_nullsep_string(self) -> list[str]:
-        """ A helper for converting a List of chars to a list of native
-        strings, starting a new string each time a null (i.e. \\x00) is seen. """
+        """A helper for converting a List of chars to a list of native
+        strings, starting a new string each time a null (i.e. \\x00) is seen."""
         return self.to_string().split("\x00")
 
     def to_utf8(self):
-        return b''.join(self).decode('utf-8')
+        return b"".join(self).decode("utf-8")
 
     def to_atoms(self):
-        """ A helper for converting a List of chars to an array of atoms """
-        return struct.unpack("<" + "%dI" % (len(self) // 4), b''.join(self))
+        """A helper for converting a List of chars to an array of atoms"""
+        return struct.unpack("<" + "%dI" % (len(self) // 4), b"".join(self))
 
     def buf(self):
         return self.raw
@@ -488,7 +485,6 @@ class List(Protobj):
 
 
 class OffsetMap(object):
-
     def __init__(self, core):
         self.offsets = [(0, 0, core)]
 
@@ -498,31 +494,35 @@ class OffsetMap(object):
 
     def get_extension_item(self, extension, item):
         try:
-            _, _, things = next((k, opcode, v) for k, opcode, v in self.offsets if opcode == extension)
+            _, _, things = next(
+                (k, opcode, v) for k, opcode, v in self.offsets if opcode == extension
+            )
             return things[item]
         except StopIteration:
             raise IndexError(item)
 
     def __getitem__(self, item):
         try:
-            offset, _, things = next((k, opcode, v) for k, opcode, v in self.offsets if item >= k)
+            offset, _, things = next(
+                (k, opcode, v) for k, opcode, v in self.offsets if item >= k
+            )
             return things[item - offset]
         except StopIteration:
             raise IndexError(item)
 
 
 class Connection(object):
+    """`auth` here should be '<name>:<data>', a format bequeathed to us from
+    xpyb."""
 
-    """ `auth` here should be '<name>:<data>', a format bequeathed to us from
-    xpyb. """
     def __init__(self, display=None, fd=-1, auth=None):
         if auth is not None:
-            [name, data] = auth.split(b':')
+            [name, data] = auth.split(b":")
 
             c_auth = ffi.new("xcb_auth_info_t *")
-            c_auth.name = ffi.new('char[]', name)
+            c_auth.name = ffi.new("char[]", name)
             c_auth.namelen = len(name)
-            c_auth.data = ffi.new('char[]', data)
+            c_auth.data = ffi.new("char[]", data)
             c_auth.datalen = len(data)
         else:
             c_auth = ffi.NULL
@@ -530,7 +530,7 @@ class Connection(object):
         if display is None:
             display = ffi.NULL
         else:
-            display = display.encode('latin1')
+            display = display.encode("latin1")
 
         i = ffi.new("int *")
 
@@ -546,8 +546,9 @@ class Connection(object):
 
     def _init_x(self):
         if core is None:
-            raise XcffibException("No core protocol object has been set.  "
-                                  "Did you import xcffib.xproto?")
+            raise XcffibException(
+                "No core protocol object has been set.  Did you import xcffib.xproto?"
+            )
 
         self.core = core(self)
         self.setup = self.get_setup()
@@ -580,6 +581,7 @@ class Connection(object):
         Check that the connection is valid both before and
         after the function is invoked.
         """
+
         @functools.wraps(f)
         def wrapper(*args):
             self = args[0]
@@ -588,6 +590,7 @@ class Connection(object):
                 return f(*args)
             finally:
                 self.invalid()
+
         return wrapper
 
     @ensure_connected
@@ -698,7 +701,7 @@ class Connection(object):
         self._process_error(err)
 
     def hoist_event(self, e):
-        """ Hoist an xcb_generic_event_t to the right xcffib structure. """
+        """Hoist an xcb_generic_event_t to the right xcffib structure."""
         if e.response_type == 0:
             return self._process_error(ffi.cast("xcb_generic_error_t *", e))
 
@@ -706,7 +709,7 @@ class Connection(object):
         # this bit set. We don't actually care where the event came from, so we
         # just throw this away. Maybe we could expose this, if anyone actually
         # cares about it.
-        response_type = e.response_type & 0x7f
+        response_type = e.response_type & 0x7F
 
         buf = CffiUnpacker(e)
         event = None
@@ -742,7 +745,6 @@ connect = Connection
 
 
 class Response(Protobj):
-
     def __init__(self, unpacker):
         Protobj.__init__(self, unpacker)
 
@@ -763,7 +765,6 @@ class Response(Protobj):
 
 
 class Reply(Response):
-
     def __init__(self, unpacker):
         Response.__init__(self, unpacker)
 
@@ -773,7 +774,6 @@ class Reply(Response):
 
 
 class Event(Response):
-
     def __init__(self, unpacker):
         # This is here for debugging purposes!
         self.unpacker = unpacker
@@ -782,11 +782,12 @@ class Event(Response):
 
         # If this is a xcb_ge_generic_event_t (response type 35) then we need a few more fields
         if self.xge and isinstance(unpacker, CffiUnpacker):
-            self.extension, self.length, self.event_type, self.full_sequence = unpacker.unpack("xB2xIH22xI")
+            self.extension, self.length, self.event_type, self.full_sequence = (
+                unpacker.unpack("xB2xIH22xI")
+            )
 
             # There's some extra work to do if the event has data past the 32 byte boundary
             if self.length:
-
                 # Calculate the size of the original buffer. This is 4 bytes short as it seems to omit the `full_sequence` field
                 buffer_size = 32 + (self.length * 4) + 4
 
@@ -794,7 +795,7 @@ class Event(Response):
                 buffer = ffi.buffer(unpacker.cdata, buffer_size)
 
                 # Copy the event to the new buffer and skip the `full_sequence` field
-                buffer[32:buffer_size - 5] = buffer[36: buffer_size - 1]
+                buffer[32 : buffer_size - 5] = buffer[36 : buffer_size - 1]
 
                 # Provide the resized buffer to the unpacker
                 unpacker.buf = buffer
@@ -805,15 +806,14 @@ class Event(Response):
 
 
 class Error(Response, XcffibException):
-
     def __init__(self, unpacker):
         Response.__init__(self, unpacker)
         XcffibException.__init__(self)
-        self.code = unpacker.unpack('B', increment=False)
+        self.code = unpacker.unpack("B", increment=False)
 
 
 def pack_list(from_, pack_type):
-    """ Return the wire packed version of `from_`. `pack_type` should be some
+    """Return the wire packed version of `from_`. `pack_type` should be some
     subclass of `xcffib.Struct`, or a string that can be passed to
     `struct.pack`. You must pass `size` if `pack_type` is a struct.pack string.
     """
@@ -821,7 +821,7 @@ def pack_list(from_, pack_type):
     if len(from_) == 0:
         return bytes()
 
-    if pack_type == 'c':
+    if pack_type == "c":
         if isinstance(from_, bytes):
             # Catch Python 3 bytes and Python 2 strings
             # PY3 is "helpful" in that when you do tuple(b'foo') you get
@@ -832,7 +832,7 @@ def pack_list(from_, pack_type):
             # Catch Python 3 strings and Python 2 unicode strings, both of
             # which we encode to bytes as utf-8
             # Here we create the tuple of bytes from the encoded string
-            from_ = [bytes((b,)) for b in bytearray(from_, 'utf-8')]
+            from_ = [bytes((b,)) for b in bytearray(from_, "utf-8")]
         elif isinstance(from_[0], int):
             # Pack from_ as char array, where from_ may be an array of ints
             # possibly greater than 256
@@ -840,6 +840,7 @@ def pack_list(from_, pack_type):
                 for _ in range(4):
                     v, r = divmod(v, 256)
                     yield r
+
             from_ = [bytes((b,)) for i in from_ for b in to_bytes(i)]
 
     if isinstance(pack_type, str):
@@ -858,7 +859,7 @@ def pack_list(from_, pack_type):
 
 
 def wrap(ptr):
-    c_conn = ffi.cast('xcb_connection_t *', ptr)
+    c_conn = ffi.cast("xcb_connection_t *", ptr)
     conn = Connection.__new__(Connection)
     conn._conn = c_conn
     conn._init_x()

--- a/module/testing.py
+++ b/module/testing.py
@@ -25,7 +25,7 @@ from . import Connection, ConnectionException
 
 
 def lock_path(display):
-    return '/tmp/.X%d-lock' % display
+    return "/tmp/.X%d-lock" % display
 
 
 def find_display():
@@ -45,10 +45,9 @@ def find_display():
 
 
 class XvfbTest:
-
-    """ A helper class for testing things with nosetests. This class will run
+    """A helper class for testing things with nosetests. This class will run
     each test in its own fresh xvfb, leaving you with an xcffib connection to
-    that X session as `self.conn` for use in testing. """
+    that X session as `self.conn` for use in testing."""
 
     # Set this to true if you'd like to get xtrace output to stdout of each
     # test.
@@ -60,26 +59,26 @@ class XvfbTest:
         self.depth = depth
 
     def spawn(self, cmd):
-        """ Spawn a command but swallow its output. """
+        """Spawn a command but swallow its output."""
         return subprocess.Popen(cmd)
 
     def _restore_display(self):
         if self._old_display is None:
-            del os.environ['DISPLAY']
+            del os.environ["DISPLAY"]
         else:
-            os.environ['DISPLAY'] = self._old_display
+            os.environ["DISPLAY"] = self._old_display
 
     def setUp(self):
-        self._old_display = os.environ.get('DISPLAY')
+        self._old_display = os.environ.get("DISPLAY")
         self._display, self._display_lock = find_display()
-        os.environ['DISPLAY'] = ':%d' % self._display
+        os.environ["DISPLAY"] = ":%d" % self._display
         self._xvfb = self.spawn(self._xvfb_command())
 
         if self.xtrace:
-            subprocess.Popen(['xtrace', '-n'])
+            subprocess.Popen(["xtrace", "-n"])
             # xtrace's default display is :9; obviously this won't work
             # concurrently, but it's not the default so...
-            os.environ['DISPLAY'] = ':9'
+            os.environ["DISPLAY"] = ":9"
         try:
             self.conn = self._connect_to_xvfb()
         except AssertionError:
@@ -121,17 +120,17 @@ class XvfbTest:
         self.tearDown()
 
     def _xvfb_command(self):
-        """ You can override this if you have some extra args for Xvfb or
+        """You can override this if you have some extra args for Xvfb or
         whatever. At this point, os.environ['DISPLAY'] is set to something Xvfb
-        can use. """
-        screen = '%sx%sx%s' % (self.width, self.height, self.depth)
-        return ['Xvfb', os.environ['DISPLAY'], '-screen', '0', screen]
+        can use."""
+        screen = "%sx%sx%s" % (self.width, self.height, self.depth)
+        return ["Xvfb", os.environ["DISPLAY"], "-screen", "0", screen]
 
     def _connect_to_xvfb(self):
         # sometimes it takes a while for Xvfb to start
         for _ in range(100):
             try:
-                conn = Connection(os.environ['DISPLAY'])
+                conn = Connection(os.environ["DISPLAY"])
                 conn.invalid()
 
                 # xvfb creates a screen with a default width, and then resizes it.

--- a/module/wrappers.py
+++ b/module/wrappers.py
@@ -16,6 +16,7 @@ def IDWrapper(freer):
     Classes create with IDWrapper return an ID and then free it upon exit of the
     context.
     """
+
     class Wrapper:
         def __init__(self, conn):
             self.conn = conn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-flake8
-autopep8
-cffi>=0.8.2
 pytest
 pytest-xdist
 cffi >= 1.6

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,9 @@ class binding_build(build):
     print a helpful message if they have not been generated yet.  We only need
     to check this when we are actually building or installing.
     """
+
     def finalize_options(self):
-        if not os.path.exists('./xcffib'):
+        if not os.path.exists("./xcffib"):
             print("It looks like you need to generate the binding.")
             print("please run 'make xcffib' or 'make check'.")
             sys.exit(1)
@@ -37,7 +38,7 @@ class binding_build(build):
 
 class binding_install(install):
     def finalize_options(self):
-        if not os.path.exists('./xcffib'):
+        if not os.path.exists("./xcffib"):
             print("It looks like you need to generate the binding.")
             print("please run 'make xcffib' or 'make check'.")
             sys.exit(1)
@@ -57,20 +58,17 @@ setup(
     author_email="tycho@tycho.pizza",
     install_requires=dependencies,
     setup_requires=dependencies,
-    python_requires = ">=3.10",
-    packages=['xcffib'],
-    package_data={'xcffib': ['py.typed']},
+    python_requires=">=3.10",
+    packages=["xcffib"],
+    package_data={"xcffib": ["py.typed"]},
     zip_safe=False,
-    cmdclass={
-        'build': binding_build,
-        'install': binding_install
-    },
+    cmdclass={"build": binding_build, "install": binding_install},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Software Development :: Libraries'
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Software Development :: Libraries",
     ],
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,7 @@ def xproto_test(xcffib_test):
 
 
 class XcffibTest(XvfbTest):
-    """ A home for common functions needed for xcffib testing. """
+    """A home for common functions needed for xcffib testing."""
 
     def setUp(self):
         XvfbTest.setUp(self)
@@ -54,16 +54,16 @@ class XcffibTest(XvfbTest):
             self.default_screen.root_depth,
             wid,
             self.default_screen.root,
-            x, y, w, h,
+            x,
+            y,
+            w,
+            h,
             0,
             xcffib.xproto.WindowClass.InputOutput,
             self.default_screen.root_visual,
             xcffib.xproto.CW.BackPixel | xcffib.xproto.CW.EventMask,
-            [
-                self.default_screen.black_pixel,
-                xcffib.xproto.EventMask.StructureNotify
-            ],
-            is_checked=is_checked
+            [self.default_screen.black_pixel, xcffib.xproto.EventMask.StructureNotify],
+            is_checked=is_checked,
         )
 
     def xeyes(self):
@@ -72,13 +72,13 @@ class XcffibTest(XvfbTest):
             self.default_screen.root,
             xcffib.xproto.CW.EventMask,
             [
-                EventMask.SubstructureNotify |
-                EventMask.StructureNotify |
-                EventMask.SubstructureRedirect
-            ]
+                EventMask.SubstructureNotify
+                | EventMask.StructureNotify
+                | EventMask.SubstructureRedirect
+            ],
         ).check()
 
-        self.spawn(['xeyes'])
+        self.spawn(["xeyes"])
 
     def intern(self, name):
         return self.xproto.InternAtom(False, len(name), name).reply().atom

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -184,7 +184,7 @@ class TestConnection:
         utf8_string = xproto_test.intern("UTF8_STRING")
 
         title_bytes = b"test\xc2\xb7"
-        title_string = "test\u00B7"
+        title_string = "test\u00b7"
 
         # First check with an object already encoded as bytes
         xproto_test.xproto.ChangeProperty(
@@ -198,7 +198,7 @@ class TestConnection:
         )
 
         reply = xproto_test.xproto.GetProperty(
-            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1
+            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2**32) - 1
         ).reply()
 
         print(reply.value.buf())
@@ -218,7 +218,7 @@ class TestConnection:
         )
 
         reply = xproto_test.xproto.GetProperty(
-            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2 ** 32) - 1
+            False, wid, net_wm_name, xcffib.xproto.GetPropertyType.Any, 0, (2**32) - 1
         ).reply()
 
         assert reply.value.buf() == title_bytes

--- a/test/test_crazy_window_script.py
+++ b/test/test_crazy_window_script.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 
 """
-    This is mostly stolen from qtile's tests/scripts/window.py
+This is mostly stolen from qtile's tests/scripts/window.py
 """
+
 import os
 import sys
 import struct

--- a/test/test_fakeinput.py
+++ b/test/test_fakeinput.py
@@ -11,35 +11,15 @@ def test_fakeinput(xcffib_test):
 
     def test(x, y):
         # motion
-        xtest.FakeInput(
-            6,
-            0,
-            xcffib.xproto.Time.CurrentTime,
-            screen.root,
-            x,
-            y,
-            0)
+        xtest.FakeInput(6, 0, xcffib.xproto.Time.CurrentTime, screen.root, x, y, 0)
 
         # press
-        xtest.FakeInput(
-            4,
-            1,
-            xcffib.xproto.Time.CurrentTime,
-            screen.root,
-            0,
-            0,
-            0)
+        xtest.FakeInput(4, 1, xcffib.xproto.Time.CurrentTime, screen.root, 0, 0, 0)
 
         # release
-        xtest.FakeInput(
-            5,
-            1,
-            xcffib.xproto.Time.CurrentTime,
-            screen.root,
-            2,
-            2,
-            0)
+        xtest.FakeInput(5, 1, xcffib.xproto.Time.CurrentTime, screen.root, 2, 2, 0)
         xcffib_test.conn.flush()
+
     test(50, 10)
 
     # we shouldn't get any errors

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -28,7 +28,9 @@ class TestConnection:
         visual = setup.roots[0].root_visual
         black = setup.roots[0].black_pixel
         conn.render = conn(xcffib.render.key)
-        conn.render.QueryVersion(xcffib.render.MAJOR_VERSION, xcffib.render.MINOR_VERSION)
+        conn.render.QueryVersion(
+            xcffib.render.MAJOR_VERSION, xcffib.render.MINOR_VERSION
+        )
 
         window = conn.generate_id()
         conn.core.CreateWindow(
@@ -65,12 +67,16 @@ class TestConnection:
                 conn.render.CreateLinearGradientChecked(
                     pic_gradient,
                     xcffib.render.POINTFIX.synthetic(0, 0),
-                    xcffib.render.POINTFIX.synthetic(double_to_fixed(WIDTH), double_to_fixed(HEIGHT)),
+                    xcffib.render.POINTFIX.synthetic(
+                        double_to_fixed(WIDTH), double_to_fixed(HEIGHT)
+                    ),
                     2,
                     [0, double_to_fixed(1)],
                     [
-                        xcffib.render.COLOR.synthetic(0, 0, 0, 0xffff),  # Solid black
-                        xcffib.render.COLOR.synthetic(0xffff, 0xffff, 0xffff, 0xffff),  # Solid white
+                        xcffib.render.COLOR.synthetic(0, 0, 0, 0xFFFF),  # Solid black
+                        xcffib.render.COLOR.synthetic(
+                            0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF
+                        ),  # Solid white
                     ],
                 ).check()
 
@@ -80,18 +86,24 @@ class TestConnection:
                     pic_gradient,
                     0,
                     pic_window,
-                    0, 0,
-                    0, 0,
-                    0, 0,
-                    WIDTH, HEIGHT
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    WIDTH,
+                    HEIGHT,
                 )
 
                 img = conn.core.GetImage(
                     xcffib.xproto.ImageFormat.ZPixmap,
                     window,
-                    0, 0,
-                    WIDTH, HEIGHT,
-                    0xffffffff
+                    0,
+                    0,
+                    WIDTH,
+                    HEIGHT,
+                    0xFFFFFFFF,
                 ).reply()
 
                 conn.flush()

--- a/test/test_xkb.py
+++ b/test/test_xkb.py
@@ -1,16 +1,13 @@
-import xcffib
-import xcffib.xproto
-
 def test_query_rules_names(xproto_test):
-    setup = xproto_test.conn.get_setup()
-
     root = xproto_test.default_screen.root
 
     string = xproto_test.intern("STRING")
     xkb_rules_names = xproto_test.intern("_XKB_RULES_NAMES")
 
     # should be enough for anybody...
-    prop = xproto_test.xproto.GetProperty(False, root, xkb_rules_names, string, 0, 64 * 1024).reply()
+    prop = xproto_test.xproto.GetProperty(
+        False, root, xkb_rules_names, string, 0, 64 * 1024
+    ).reply()
 
     strings = prop.value.to_nullsep_string()
     # xephyr's defaults


### PR DESCRIPTION
this is fast enough that we can *always* use it on the generated output now, vs autopep8 which was quite slow and I always forgot to invoke during releases. this means that the generated bindings will be pep8 formatted, as people asked me to do many years ago but I have constantly forgotten to do :)

My intent here was really to fix some whitespace noise that had been floating around for a while and I had manually pruned from other commits when peoples' editors auto fixed it, but if we're going to do that, we might as well move to standard formatting too...