### PR TITLE
module: guard against null return from xcb_get_extension_data()

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -549,6 +549,13 @@ class Connection(object):
     def _setup_extensions(self):
         for key, (_, events, errors) in extensions.items():
             reply = lib.xcb_get_extension_data(self._conn, key.c_key)
+            # although it does not say so in the man page,
+            # xcb_get_extension_data() will return NULL if the connection has
+            # an error. let's guard against this, and do our own connection
+            # checking in this case.
+            if reply == ffi.NULL:
+                self.invalid()
+                raise XcffibException("uh oh... connection valid but xcb_get_extension_data() returned NULL?")
             self._event_offsets.add(reply.first_event, reply.major_opcode, events)
             self._error_offsets.add(reply.first_error, reply.major_opcode, errors)
 


### PR DESCRIPTION
see comment for details... this probably doesn't *really* occur in the wild very much, but we uncovered it in our parallel testing, and didn't quite get it fixed in d3c25ee422a5 ("module: be less strange about extension key lifetimes") (although that was probably also a bug and a nice cleanup anyway at net negative lines, this is likely the real source of the seg fault).