### PR TITLE
add a better __repr__

### DIFF
--- a/generator/Data/XCB/Python/AST.hs
+++ b/generator/Data/XCB/Python/AST.hs
@@ -195,8 +195,8 @@ instance Pretty Statement where
     pretty (Fun name args bod) = text "def" <+> pretty name <> (parens (addCommas args)) <> colon
                                  $+$ indent (pretty bod)
     pretty (Decorated decorator name args bod) = text "@" <> text decorator $+$ pretty (Fun name args bod)
-    pretty (Class name [] body) = text "class" <+> pretty name <> colon $+$ indent (pretty body)
-    pretty (Class name superclasses body) = text "class" <+> pretty name <> parens (addCommas superclasses) <> colon $+$ indent (pretty body)
+    pretty (Class name [] body) = text "@dataclass(init=False)" $+$ text "class" <+> pretty name <> colon $+$ indent (pretty body)
+    pretty (Class name superclasses body) = text "@dataclass(init=False)" $+$ text "class" <+> pretty name <> parens (addCommas superclasses) <> colon $+$ indent (pretty body)
     pretty (Conditional cond if_ else_) = text "if" <+> pretty cond <> colon $+$ indent (pretty if_) $+$ pretty else_
     pretty (Assign to expr) = pretty to <+> text "=" <+> pretty expr
     pretty (AugmentedAssign to op expr) = pretty to <+> pretty op <> text "=" <+> pretty expr

--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -90,7 +90,7 @@ xform = map buildPython . dependencyOrder
     processXHeader :: XHeader
                    -> State TypeInfoMap (String, Suite)
     processXHeader header = do
-      let imports = [Import "xcffib", Import "struct", Import "io"]
+      let imports = [Import "xcffib", Import "struct", Import "io", FromImport "dataclasses" "dataclass"]
           version = mkVersion header
           key = maybeToList $ mkKey header
           globals = [mkDict "_events", mkDict "_errors"]

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -399,6 +399,7 @@ class Extension(object):
 class List(Protobj):
     def __init__(self, unpacker, typ, count=None):
         Protobj.__init__(self, unpacker)
+        self.typ = typ
 
         self.list = []
         old = unpacker.offset
@@ -438,6 +439,15 @@ class List(Protobj):
 
     def __delitem__(self, key):
         del self.list[key]
+
+    def __repr__(self):
+        # the spec uses both CHAR8 and VOID to indicate strings, we stringify
+        # both here. this is of course a heuristic, because it uses VOID to
+        # mean other things, but this just debug code, so it's probably fine...
+        if self.typ in ["c", "B"]:
+            return "\"" + self.to_string() + "\""
+        else:
+            return "[" + ", ".join(repr(i) for i in self) + "]"
 
     def to_string(self):
         """A helper for converting a List of chars to a native string. Dies if

--- a/test/generator/enum.py
+++ b/test/generator/enum.py
@@ -1,14 +1,17 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class DeviceUse:
     IsXPointer = 0
     IsXKeyboard = 1
     IsXExtensionDevice = 2
     IsXExtensionKeyboard = 3
     IsXExtensionPointer = 4
+@dataclass(init=False)
 class EventMask:
     NoEvent = 0
     KeyPress = 1 << 0

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
 key = xcffib.ExtensionKey("ERROR")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class RequestError(xcffib.Error):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 4
 key = xcffib.ExtensionKey("EVENT")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class ScreenChangeNotifyEvent(xcffib.Event):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/eventstruct.py
+++ b/test/generator/eventstruct.py
@@ -1,10 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class EventForSend(xcffib.Buffer):
     pass
+@dataclass(init=False)
 class eventstructExtension(xcffib.Extension):
     def SendExtensionEvent(self, device_id, propagate, num_classes, num_events, events, classes, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class KeymapNotifyEvent(xcffib.Event):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/randr.py
+++ b/test/generator/randr.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 6
 key = xcffib.ExtensionKey("RANDR")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class TRANSFORM(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -33,6 +35,7 @@ class TRANSFORM(xcffib.Struct):
         self.matrix32 = matrix32
         self.matrix33 = matrix33
         return self
+@dataclass(init=False)
 class GetCrtcTransformReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -55,8 +58,10 @@ class GetCrtcTransformReply(xcffib.Reply):
         unpacker.pad("i")
         self.current_params = xcffib.List(unpacker, "i", self.current_nparams)
         self.bufsize = unpacker.offset - base
+@dataclass(init=False)
 class GetCrtcTransformCookie(xcffib.Cookie):
     reply_type = GetCrtcTransformReply
+@dataclass(init=False)
 class randrExtension(xcffib.Extension):
     def GetCrtcTransform(self, crtc, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/record.py
+++ b/test/generator/record.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 13
 key = xcffib.ExtensionKey("RECORD")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class Range8(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -26,6 +28,7 @@ class Range8(xcffib.Struct):
         self.first = first
         self.last = last
         return self
+@dataclass(init=False)
 class Range16(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -46,6 +49,7 @@ class Range16(xcffib.Struct):
         self.first = first
         self.last = last
         return self
+@dataclass(init=False)
 class ExtRange(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -68,6 +72,7 @@ class ExtRange(xcffib.Struct):
         self.major = major
         self.minor = minor
         return self
+@dataclass(init=False)
 class Range(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class COLOR(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -28,6 +30,7 @@ class COLOR(xcffib.Struct):
         self.blue = blue
         self.alpha = alpha
         return self
+@dataclass(init=False)
 class RECTANGLE(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -50,6 +53,7 @@ class RECTANGLE(xcffib.Struct):
         self.width = width
         self.height = height
         return self
+@dataclass(init=False)
 class renderExtension(xcffib.Extension):
     def FillRectangles(self, op, dst, color, rects_len, rects, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/render_1.7.py
+++ b/test/generator/render_1.7.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class PictOp:
     Clear = 0
     Src = 1

--- a/test/generator/request.py
+++ b/test/generator/request.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class requestExtension(xcffib.Extension):
     def CreateWindow(self, depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class STR(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -24,6 +26,7 @@ class STR(xcffib.Struct):
         self.name_len = name_len
         self.name = name
         return self
+@dataclass(init=False)
 class ListExtensionsReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -34,8 +37,10 @@ class ListExtensionsReply(xcffib.Reply):
         self.names_len, = unpacker.unpack("xB2x4x24x")
         self.names = xcffib.List(unpacker, STR, self.names_len)
         self.bufsize = unpacker.offset - base
+@dataclass(init=False)
 class ListExtensionsCookie(xcffib.Cookie):
     reply_type = ListExtensionsReply
+@dataclass(init=False)
 class request_replyExtension(xcffib.Extension):
     def ListExtensions(self, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class AxisInfo(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -24,6 +26,7 @@ class AxisInfo(xcffib.Struct):
         self.minimum = minimum
         self.maximum = maximum
         return self
+@dataclass(init=False)
 class ValuatorInfo(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class INT64(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -23,6 +25,7 @@ class INT64(xcffib.Struct):
         self.hi = hi
         self.lo = lo
         return self
+@dataclass(init=False)
 class GetPropertyReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -38,8 +41,10 @@ class GetPropertyReply(xcffib.Reply):
         if self.format & PropertyFormat._32Bits:
             self.data32 = xcffib.List(unpacker, "I", self.num_items)
         self.bufsize = unpacker.offset - base
+@dataclass(init=False)
 class GetPropertyCookie(xcffib.Cookie):
     reply_type = GetPropertyReply
+@dataclass(init=False)
 class GetPropertyWithPadReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -59,8 +64,10 @@ class GetPropertyWithPadReply(xcffib.Reply):
             unpacker.pad("I")
             self.data32 = xcffib.List(unpacker, "I", self.num_items)
         self.bufsize = unpacker.offset - base
+@dataclass(init=False)
 class GetPropertyWithPadCookie(xcffib.Cookie):
     reply_type = GetPropertyWithPadReply
+@dataclass(init=False)
 class switchExtension(xcffib.Extension):
     def GetProperty(self, value_mask, items, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class CHARINFO(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -27,6 +29,7 @@ class CHARINFO(xcffib.Struct):
         self.descent = descent
         self.attributes = attributes
         return self
+@dataclass(init=False)
 class FONTPROP(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -47,6 +50,7 @@ class FONTPROP(xcffib.Struct):
         self.name = name
         self.value = value
         return self
+@dataclass(init=False)
 class ListFontsWithInfoReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -65,8 +69,10 @@ class ListFontsWithInfoReply(xcffib.Reply):
         unpacker.pad("c")
         self.name = xcffib.List(unpacker, "c", self.name_len)
         self.bufsize = unpacker.offset - base
+@dataclass(init=False)
 class ListFontsWithInfoCookie(xcffib.Cookie):
     reply_type = ListFontsWithInfoReply
+@dataclass(init=False)
 class type_padExtension(xcffib.Extension):
     def ListFontsWithInfo(self, max_names, pattern_len, pattern, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/union.py
+++ b/test/generator/union.py
@@ -1,8 +1,10 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class ClientMessageData(xcffib.Union):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/xproto_1.7.py
+++ b/test/generator/xproto_1.7.py
@@ -1,11 +1,13 @@
 import xcffib
 import struct
 import io
+from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("XPROTO")
 _events = {}
 _errors = {}
+@dataclass(init=False)
 class Atom:
     _None = 0
     Any = 0


### PR DESCRIPTION
For debugging purposes, it is useful to be able to just print(thing) and get something better than:

    <xcffib.randr.GetOutputInfoReply object at 0x7f61cebd46b0>

even with pprint, you get stuff like:

    {'bufsize': 54,
     'clones': <xcffib.List object at 0x7f61ced2b410>,
     'connection': 1,
     'crtc': 0,
     'crtcs': <xcffib.List object at 0x7f61ced2b5f0>,
    ...

instead, let's render something like:

    {'bufsize': 186, 'response_type': 1, 'sequence': 15, 'length': 39, 'status': 0, 'timestamp': 220242005, 'crtc': 64, 'mm_width': 597, 'mm_height': 336, 'connection': 0, 'subpixel_order': 0, 'num_crtcs': 3, 'num_modes': 33, 'num_preferred': 1, 'num_clones': 0, 'name_len': 6, 'crtcs': [62, 63, 64], 'modes': [238, 239, 85, 240, 241, 100, 242, 236, 243, 244, 245, 246, 247, 110, 111, 120, 121, 132, 134, 248, 249, 250, 143, 145, 172, 173, 251, 252, 253, 192, 254, 193, 237], 'clones': [], 'name': "DP-2-8"}

Fixes #182