### PR TITLE
fix __repr__ for structs

### DIFF
--- a/generator/Data/XCB/Python/AST.hs
+++ b/generator/Data/XCB/Python/AST.hs
@@ -195,8 +195,8 @@ instance Pretty Statement where
     pretty (Fun name args bod) = text "def" <+> pretty name <> (parens (addCommas args)) <> colon
                                  $+$ indent (pretty bod)
     pretty (Decorated decorator name args bod) = text "@" <> text decorator $+$ pretty (Fun name args bod)
-    pretty (Class name [] body) = text "@dataclass(init=False)" $+$ text "class" <+> pretty name <> colon $+$ indent (pretty body)
-    pretty (Class name superclasses body) = text "@dataclass(init=False)" $+$ text "class" <+> pretty name <> parens (addCommas superclasses) <> colon $+$ indent (pretty body)
+    pretty (Class name [] body) = text "class" <+> pretty name <> colon $+$ indent (pretty body)
+    pretty (Class name superclasses body) = text "class" <+> pretty name <> parens (addCommas superclasses) <> colon $+$ indent (pretty body)
     pretty (Conditional cond if_ else_) = text "if" <+> pretty cond <> colon $+$ indent (pretty if_) $+$ pretty else_
     pretty (Assign to expr) = pretty to <+> text "=" <+> pretty expr
     pretty (AugmentedAssign to op expr) = pretty to <+> pretty op <> text "=" <+> pretty expr

--- a/generator/Data/XCB/Python/Parse.hs
+++ b/generator/Data/XCB/Python/Parse.hs
@@ -90,7 +90,7 @@ xform = map buildPython . dependencyOrder
     processXHeader :: XHeader
                    -> State TypeInfoMap (String, Suite)
     processXHeader header = do
-      let imports = [Import "xcffib", Import "struct", Import "io", FromImport "dataclasses" "dataclass"]
+      let imports = [Import "xcffib", Import "struct", Import "io"]
           version = mkVersion header
           key = maybeToList $ mkKey header
           globals = [mkDict "_events", mkDict "_errors"]

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -292,6 +292,21 @@ class Protobj(object):
         if unpacker.known_max is not None:
             self.bufsize = unpacker.known_max
 
+    def __repr__(self):
+        guts = []
+        for k in dir(self):
+            # skip all the python generated gunk
+            if k.startswith("__"):
+                continue
+
+            attr = getattr(self, k)
+            # skip synthetic(), pack(), etc.
+            if callable(attr):
+                continue
+
+            guts.append(f"{k}={attr}")
+        return f"{self.__class__.__qualname__}({', '.join(guts)})"
+
 
 class Buffer(Protobj):
     def __init__(self, unpacker):

--- a/test/generator/action.py
+++ b/test/generator/action.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class SANoAction(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -24,7 +22,6 @@ class SANoAction(xcffib.Struct):
         self = cls.__new__(cls)
         self.type = type
         return self
-@dataclass(init=False)
 class SASetMods(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -49,7 +46,6 @@ class SASetMods(xcffib.Struct):
         self.vmodsHigh = vmodsHigh
         self.vmodsLow = vmodsLow
         return self
-@dataclass(init=False)
 class SASetGroup(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -71,12 +67,10 @@ class SASetGroup(xcffib.Struct):
         self.flags = flags
         self.group = group
         return self
-@dataclass(init=False)
 class SAMovePtrFlag:
     NoAcceleration = 1 << 0
     MoveAbsoluteX = 1 << 1
     MoveAbsoluteY = 1 << 2
-@dataclass(init=False)
 class SAMovePtr(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -101,7 +95,6 @@ class SAMovePtr(xcffib.Struct):
         self.yHigh = yHigh
         self.yLow = yLow
         return self
-@dataclass(init=False)
 class SAPtrBtn(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -124,7 +117,6 @@ class SAPtrBtn(xcffib.Struct):
         self.count = count
         self.button = button
         return self
-@dataclass(init=False)
 class SALockPtrBtn(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -146,7 +138,6 @@ class SALockPtrBtn(xcffib.Struct):
         self.flags = flags
         self.button = button
         return self
-@dataclass(init=False)
 class Action(xcffib.Union):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/enum.py
+++ b/test/generator/enum.py
@@ -1,17 +1,14 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class DeviceUse:
     IsXPointer = 0
     IsXKeyboard = 1
     IsXExtensionDevice = 2
     IsXExtensionKeyboard = 3
     IsXExtensionPointer = 4
-@dataclass(init=False)
 class EventMask:
     NoEvent = 0
     KeyPress = 1 << 0

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 2
 MINOR_VERSION = 2
 key = xcffib.ExtensionKey("ERROR")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class RequestError(xcffib.Error):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 4
 key = xcffib.ExtensionKey("EVENT")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class ScreenChangeNotifyEvent(xcffib.Event):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/eventstruct.py
+++ b/test/generator/eventstruct.py
@@ -1,13 +1,10 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class EventForSend(xcffib.Buffer):
     pass
-@dataclass(init=False)
 class eventstructExtension(xcffib.Extension):
     def SendExtensionEvent(self, device_id, propagate, num_classes, num_events, events, classes, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class KeymapNotifyEvent(xcffib.Event):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/randr.py
+++ b/test/generator/randr.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 6
 key = xcffib.ExtensionKey("RANDR")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class TRANSFORM(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -35,7 +33,6 @@ class TRANSFORM(xcffib.Struct):
         self.matrix32 = matrix32
         self.matrix33 = matrix33
         return self
-@dataclass(init=False)
 class GetCrtcTransformReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -58,10 +55,8 @@ class GetCrtcTransformReply(xcffib.Reply):
         unpacker.pad("i")
         self.current_params = xcffib.List(unpacker, "i", self.current_nparams)
         self.bufsize = unpacker.offset - base
-@dataclass(init=False)
 class GetCrtcTransformCookie(xcffib.Cookie):
     reply_type = GetCrtcTransformReply
-@dataclass(init=False)
 class randrExtension(xcffib.Extension):
     def GetCrtcTransform(self, crtc, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/record.py
+++ b/test/generator/record.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 1
 MINOR_VERSION = 13
 key = xcffib.ExtensionKey("RECORD")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class Range8(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -28,7 +26,6 @@ class Range8(xcffib.Struct):
         self.first = first
         self.last = last
         return self
-@dataclass(init=False)
 class Range16(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -49,7 +46,6 @@ class Range16(xcffib.Struct):
         self.first = first
         self.last = last
         return self
-@dataclass(init=False)
 class ExtRange(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -72,7 +68,6 @@ class ExtRange(xcffib.Struct):
         self.major = major
         self.minor = minor
         return self
-@dataclass(init=False)
 class Range(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class COLOR(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -30,7 +28,6 @@ class COLOR(xcffib.Struct):
         self.blue = blue
         self.alpha = alpha
         return self
-@dataclass(init=False)
 class RECTANGLE(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -53,7 +50,6 @@ class RECTANGLE(xcffib.Struct):
         self.width = width
         self.height = height
         return self
-@dataclass(init=False)
 class renderExtension(xcffib.Extension):
     def FillRectangles(self, op, dst, color, rects_len, rects, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/render_1.7.py
+++ b/test/generator/render_1.7.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("RENDER")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class PictOp:
     Clear = 0
     Src = 1

--- a/test/generator/request.py
+++ b/test/generator/request.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class requestExtension(xcffib.Extension):
     def CreateWindow(self, depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list, is_checked=False):
         buf = io.BytesIO()

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class STR(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -26,7 +24,6 @@ class STR(xcffib.Struct):
         self.name_len = name_len
         self.name = name
         return self
-@dataclass(init=False)
 class ListExtensionsReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -37,10 +34,8 @@ class ListExtensionsReply(xcffib.Reply):
         self.names_len, = unpacker.unpack("xB2x4x24x")
         self.names = xcffib.List(unpacker, STR, self.names_len)
         self.bufsize = unpacker.offset - base
-@dataclass(init=False)
 class ListExtensionsCookie(xcffib.Cookie):
     reply_type = ListExtensionsReply
-@dataclass(init=False)
 class request_replyExtension(xcffib.Extension):
     def ListExtensions(self, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class AxisInfo(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -26,7 +24,6 @@ class AxisInfo(xcffib.Struct):
         self.minimum = minimum
         self.maximum = maximum
         return self
-@dataclass(init=False)
 class ValuatorInfo(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class INT64(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -25,7 +23,6 @@ class INT64(xcffib.Struct):
         self.hi = hi
         self.lo = lo
         return self
-@dataclass(init=False)
 class GetPropertyReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -41,10 +38,8 @@ class GetPropertyReply(xcffib.Reply):
         if self.format & PropertyFormat._32Bits:
             self.data32 = xcffib.List(unpacker, "I", self.num_items)
         self.bufsize = unpacker.offset - base
-@dataclass(init=False)
 class GetPropertyCookie(xcffib.Cookie):
     reply_type = GetPropertyReply
-@dataclass(init=False)
 class GetPropertyWithPadReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -64,10 +59,8 @@ class GetPropertyWithPadReply(xcffib.Reply):
             unpacker.pad("I")
             self.data32 = xcffib.List(unpacker, "I", self.num_items)
         self.bufsize = unpacker.offset - base
-@dataclass(init=False)
 class GetPropertyWithPadCookie(xcffib.Cookie):
     reply_type = GetPropertyWithPadReply
-@dataclass(init=False)
 class switchExtension(xcffib.Extension):
     def GetProperty(self, value_mask, items, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class CHARINFO(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -29,7 +27,6 @@ class CHARINFO(xcffib.Struct):
         self.descent = descent
         self.attributes = attributes
         return self
-@dataclass(init=False)
 class FONTPROP(xcffib.Struct):
     xge = False
     def __init__(self, unpacker):
@@ -50,7 +47,6 @@ class FONTPROP(xcffib.Struct):
         self.name = name
         self.value = value
         return self
-@dataclass(init=False)
 class ListFontsWithInfoReply(xcffib.Reply):
     xge = False
     def __init__(self, unpacker):
@@ -69,10 +65,8 @@ class ListFontsWithInfoReply(xcffib.Reply):
         unpacker.pad("c")
         self.name = xcffib.List(unpacker, "c", self.name_len)
         self.bufsize = unpacker.offset - base
-@dataclass(init=False)
 class ListFontsWithInfoCookie(xcffib.Cookie):
     reply_type = ListFontsWithInfoReply
-@dataclass(init=False)
 class type_padExtension(xcffib.Extension):
     def ListFontsWithInfo(self, max_names, pattern_len, pattern, is_checked=True):
         buf = io.BytesIO()

--- a/test/generator/union.py
+++ b/test/generator/union.py
@@ -1,10 +1,8 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class ClientMessageData(xcffib.Union):
     xge = False
     def __init__(self, unpacker):

--- a/test/generator/xproto_1.7.py
+++ b/test/generator/xproto_1.7.py
@@ -1,13 +1,11 @@
 import xcffib
 import struct
 import io
-from dataclasses import dataclass
 MAJOR_VERSION = 0
 MINOR_VERSION = 11
 key = xcffib.ExtensionKey("XPROTO")
 _events = {}
 _errors = {}
-@dataclass(init=False)
 class Atom:
     _None = 0
     Any = 0

--- a/test/test_python_code.py
+++ b/test/test_python_code.py
@@ -194,6 +194,22 @@ class TestPythonCode:
         finally:
             xcffib_test.conn.disconnect()
 
+    def test_replies_are_hashable(self, xcffib_test):
+        # I have written code that relied on replies being hash()-able, and
+        # we have broken that. So let's generate a reply and hash() it and make
+        # sure that works.
+        setup = xcffib_test.conn.get_setup()
+        hash(setup)
+
+    def test_protobj_repr_is_reasonable(self, xcffib_test):
+        # make sure that repr() does something reasonable
+        setup = xcffib_test.conn.get_setup()
+        assert "FORMAT(bits_per_pixel=1, bufsize=8, depth=1, fixed_size=8, scanline_pad=32, xge=False)" == repr(setup.pixmap_formats[0])
+
+    def test_list_repr_of_chars_is_reasonable(self, xcffib_test):
+        setup = xcffib_test.conn.get_setup()
+        assert "\"The X.Org Foundation\"" == repr(setup.vendor)
+
 
 class TestXcffibTestGenerator:
     def test_XcffibTest_generator(self):


### PR DESCRIPTION
c7d7bf83b522 ("add a better __repr__") seems to not really have worked; I'm not sure why I thought it did, but the results are bogus (i.e. there is no members in the resulting structures).

Let's just define our own on Protobj, without @dataclass hacks. it's not that much code: we just skip a few irrelevant things, and look in our own __dir__.

We keep the list special casing, and add tests for all of these, and hashing, which was something I was using that broke.