### PR TITLE
ci: don't run twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: ci
 
 on:
     push:
+      branches:
+        - master
     pull_request:
     schedule:
         - cron: '0 0 * * 0' # weekly


### PR DESCRIPTION
when I make PRs to this repo, the CI runs twice, once for my push, and once for the PR. let's only do CI on PRs and the master branch.