### PR TITLE
don't use __getattr__for Checked reasoning

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -400,19 +400,6 @@ class Extension(object):
 
         return cookie(self.conn, seq, is_checked)
 
-    def __getattr__(self, name):
-        if name.endswith("Checked"):
-            real = name[: -len("Checked")]
-            is_checked = True
-        elif name.endswith("Unchecked"):
-            real = name[: -len("Unchecked")]
-            is_checked = False
-        else:
-            raise AttributeError(name)
-
-        real = getattr(self, real)
-
-        return functools.partial(real, is_checked=is_checked)
 
 
 class List(Protobj):

--- a/test/generator/eventstruct.py
+++ b/test/generator/eventstruct.py
@@ -12,4 +12,6 @@ class eventstructExtension(xcffib.Extension):
         buf.write(xcffib.pack_list(events, EventForSend))
         buf.write(xcffib.pack_list(classes, "B"))
         return self.send_request(31, buf, is_checked=is_checked)
+    def SendExtensionEventChecked(self, device_id, propagate, num_classes, num_events, events, classes):
+        return self.SendExtensionEvent(device_id, propagate, num_classes, num_events, events, classes, is_checked=True)
 xcffib._add_ext(key, eventstructExtension, _events, _errors)

--- a/test/generator/randr.py
+++ b/test/generator/randr.py
@@ -62,4 +62,6 @@ class randrExtension(xcffib.Extension):
         buf = io.BytesIO()
         buf.write(struct.pack("=xx2xI", crtc))
         return self.send_request(27, buf, GetCrtcTransformCookie, is_checked=is_checked)
+    def GetCrtcTransformUnchecked(self, crtc):
+        return self.GetCrtcTransform(crtc, is_checked=False)
 xcffib._add_ext(key, randrExtension, _events, _errors)

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -57,4 +57,6 @@ class renderExtension(xcffib.Extension):
         buf.write(color.pack() if hasattr(color, "pack") else COLOR.synthetic(*color).pack())
         buf.write(xcffib.pack_list(rects, RECTANGLE))
         return self.send_request(26, buf, is_checked=is_checked)
+    def FillRectanglesChecked(self, op, dst, color, rects_len, rects):
+        return self.FillRectangles(op, dst, color, rects_len, rects, is_checked=True)
 xcffib._add_ext(key, renderExtension, _events, _errors)

--- a/test/generator/request.py
+++ b/test/generator/request.py
@@ -10,4 +10,6 @@ class requestExtension(xcffib.Extension):
         buf.write(struct.pack("=I", value_mask))
         buf.write(xcffib.pack_list(value_list, "I"))
         return self.send_request(1, buf, is_checked=is_checked)
+    def CreateWindowChecked(self, depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list):
+        return self.CreateWindow(depth, wid, parent, x, y, width, height, border_width, _class, visual, value_mask, value_list, is_checked=True)
 xcffib._add_ext(key, requestExtension, _events, _errors)

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -41,4 +41,6 @@ class request_replyExtension(xcffib.Extension):
         buf = io.BytesIO()
         buf.write(struct.pack("=xx2x"))
         return self.send_request(99, buf, ListExtensionsCookie, is_checked=is_checked)
+    def ListExtensionsUnchecked(self):
+        return self.ListExtensions(is_checked=False)
 xcffib._add_ext(key, request_replyExtension, _events, _errors)

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -78,8 +78,12 @@ class switchExtension(xcffib.Extension):
             events = items.pop(0)
             buf.write(struct.pack("=I", events))
         return self.send_request(59, buf, GetPropertyCookie, is_checked=is_checked)
+    def GetPropertyUnchecked(self, value_mask, items):
+        return self.GetProperty(value_mask, items, is_checked=False)
     def GetPropertyWithPad(self, is_checked=True):
         buf = io.BytesIO()
         buf.write(struct.pack("=xx2x"))
         return self.send_request(60, buf, GetPropertyWithPadCookie, is_checked=is_checked)
+    def GetPropertyWithPadUnchecked(self):
+        return self.GetPropertyWithPad(is_checked=False)
 xcffib._add_ext(key, switchExtension, _events, _errors)

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -73,4 +73,6 @@ class type_padExtension(xcffib.Extension):
         buf.write(struct.pack("=xx2xxHH", max_names, pattern_len))
         buf.write(xcffib.pack_list(pattern, "c"))
         return self.send_request(50, buf, ListFontsWithInfoCookie, is_checked=is_checked)
+    def ListFontsWithInfoUnchecked(self, max_names, pattern_len, pattern):
+        return self.ListFontsWithInfo(max_names, pattern_len, pattern, is_checked=False)
 xcffib._add_ext(key, type_padExtension, _events, _errors)


### PR DESCRIPTION
While profiling Qtile, I noticed:

    2   xcffib/__init__.py:401                   17.3 KiB
        real = name[: -len("Checked")]

we generate a *ton* of memory allocations for these Checked and Unchecked calls where the default is otherwise. I like this flexibility, but it is annoying that it generates so many allocations.

So instead, let's generate a bigger vtable :). We can generate Checked and Unchecked variants of each method, that call the underlying version with the boolean flag. This way there are no (runtime) allocations, "just" a vtable that's twice as big. But e.g. for xproto, it was already huge anyway, so I don't expect a huge performance hit here...