### PR TITLE
generator: add = prefix to all unpack() arguments

### DIFF
--- a/generator/Data/XCB/Python/PyHelpers.hs
+++ b/generator/Data/XCB/Python/PyHelpers.hs
@@ -106,7 +106,8 @@ mkUnpackFrom unpacker names packs =
   let lhs = Tuple $ map mkAttr names
       -- Don't spam with this default arg unless it is really necessary.
       unpackF = mkDot unpacker "unpack"
-      rhs = mkCall unpackF [mkStr packs]
+      packs' = if null packs then packs else '=' : packs
+      rhs = mkCall unpackF [mkStr packs']
       stmt = if length names > 0 then mkAssign lhs rhs else StmtExpr rhs
   in if length packs > 0 then [stmt] else []
 

--- a/module/__init__.py
+++ b/module/__init__.py
@@ -106,7 +106,6 @@ class Unpacker(object):
         self.offset += type_pad(size, self.offset)
 
     def unpack(self, fmt, increment=True):
-        fmt = "=" + fmt
         size = struct.calcsize(fmt)
         if size > self.size - self.offset:
             self._resize(size)
@@ -411,7 +410,7 @@ class List(Protobj):
         old = unpacker.offset
 
         if isinstance(typ, str):
-            self.list = list(unpacker.unpack("%d%s" % (count, typ)))
+            self.list = list(unpacker.unpack("=%d%s" % (count, typ)))
         elif count is not None:
             for _ in range(count):
                 item = typ(unpacker)
@@ -727,7 +726,7 @@ class Connection(object):
         # extension event.
         if response_type == 35:
             # Extract the extension opcode and event
-            extension, _, event_type, _ = buf.unpack("xB2xIH22xI", increment=False)
+            extension, _, event_type, _ = buf.unpack("=xB2xIH22xI", increment=False)
             try:
                 # Try to find matching event. If this fails, an IndexError is raised and
                 # we'll fall back to raising an GeGenericEvent
@@ -792,7 +791,7 @@ class Event(Response):
         # If this is a xcb_ge_generic_event_t (response type 35) then we need a few more fields
         if self.xge and isinstance(unpacker, CffiUnpacker):
             self.extension, self.length, self.event_type, self.full_sequence = (
-                unpacker.unpack("xB2xIH22xI")
+                unpacker.unpack("=xB2xIH22xI")
             )
 
             # There's some extra work to do if the event has data past the 32 byte boundary
@@ -818,7 +817,7 @@ class Error(Response, XcffibException):
     def __init__(self, unpacker):
         Response.__init__(self, unpacker)
         XcffibException.__init__(self)
-        self.code = unpacker.unpack("B", increment=False)
+        self.code = unpacker.unpack("=B", increment=False)
 
 
 def pack_list(from_, pack_type):

--- a/test/generator/action.py
+++ b/test/generator/action.py
@@ -10,7 +10,7 @@ class SANoAction(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, = unpacker.unpack("B7x")
+        self.type, = unpacker.unpack("=B7x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -29,7 +29,7 @@ class SASetMods(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, self.flags, self.mask, self.realMods, self.vmodsHigh, self.vmodsLow = unpacker.unpack("BBBBBB2x")
+        self.type, self.flags, self.mask, self.realMods, self.vmodsHigh, self.vmodsLow = unpacker.unpack("=BBBBBB2x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -53,7 +53,7 @@ class SASetGroup(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, self.flags, self.group = unpacker.unpack("BBb5x")
+        self.type, self.flags, self.group = unpacker.unpack("=BBb5x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -78,7 +78,7 @@ class SAMovePtr(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, self.flags, self.xHigh, self.xLow, self.yHigh, self.yLow = unpacker.unpack("BBbBbB2x")
+        self.type, self.flags, self.xHigh, self.xLow, self.yHigh, self.yLow = unpacker.unpack("=BBbBbB2x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -102,7 +102,7 @@ class SAPtrBtn(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, self.flags, self.count, self.button = unpacker.unpack("BBBB4x")
+        self.type, self.flags, self.count, self.button = unpacker.unpack("=BBBB4x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -124,7 +124,7 @@ class SALockPtrBtn(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.type, self.flags, self.button = unpacker.unpack("BBxB4x")
+        self.type, self.flags, self.button = unpacker.unpack("=BBxB4x")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -152,7 +152,7 @@ class Action(xcffib.Union):
         self.moveptr = SAMovePtr(unpacker.copy())
         self.ptrbtn = SAPtrBtn(unpacker.copy())
         self.lockptrbtn = SALockPtrBtn(unpacker.copy())
-        self.type, = unpacker.copy().unpack("B")
+        self.type, = unpacker.copy().unpack("=B")
     def pack(self):
         buf = io.BytesIO()
         buf.write(self.noaction.pack() if hasattr(self.noaction, "pack") else SANoAction.synthetic(*self.noaction).pack())

--- a/test/generator/error.py
+++ b/test/generator/error.py
@@ -13,7 +13,7 @@ class RequestError(xcffib.Error):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Error.__init__(self, unpacker)
         base = unpacker.offset
-        self.bad_value, self.minor_opcode, self.major_opcode = unpacker.unpack("xx2xIHBx")
+        self.bad_value, self.minor_opcode, self.major_opcode = unpacker.unpack("=xx2xIHBx")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()

--- a/test/generator/event.py
+++ b/test/generator/event.py
@@ -13,7 +13,7 @@ class ScreenChangeNotifyEvent(xcffib.Event):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Event.__init__(self, unpacker)
         base = unpacker.offset
-        self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight = unpacker.unpack("xB2xIIIIHHHHHH")
+        self.rotation, self.timestamp, self.config_timestamp, self.root, self.request_window, self.sizeID, self.subpixel_order, self.width, self.height, self.mwidth, self.mheight = unpacker.unpack("=xB2xIIIIHHHHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()

--- a/test/generator/no_sequence.py
+++ b/test/generator/no_sequence.py
@@ -10,7 +10,7 @@ class KeymapNotifyEvent(xcffib.Event):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Event.__init__(self, unpacker)
         base = unpacker.offset
-        unpacker.unpack("x")
+        unpacker.unpack("=x")
         self.keys = xcffib.List(unpacker, "B", 31)
         self.bufsize = unpacker.offset - base
     def pack(self):

--- a/test/generator/randr.py
+++ b/test/generator/randr.py
@@ -13,7 +13,7 @@ class TRANSFORM(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.matrix11, self.matrix12, self.matrix13, self.matrix21, self.matrix22, self.matrix23, self.matrix31, self.matrix32, self.matrix33 = unpacker.unpack("iiiiiiiii")
+        self.matrix11, self.matrix12, self.matrix13, self.matrix21, self.matrix22, self.matrix23, self.matrix31, self.matrix32, self.matrix33 = unpacker.unpack("=iiiiiiiii")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -40,12 +40,12 @@ class GetCrtcTransformReply(xcffib.Reply):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Reply.__init__(self, unpacker)
         base = unpacker.offset
-        unpacker.unpack("xx2x4x")
+        unpacker.unpack("=xx2x4x")
         self.pending_transform = TRANSFORM(unpacker)
-        self.has_transforms, = unpacker.unpack("B3x")
+        self.has_transforms, = unpacker.unpack("=B3x")
         unpacker.pad(TRANSFORM)
         self.current_transform = TRANSFORM(unpacker)
-        self.pending_len, self.pending_nparams, self.current_len, self.current_nparams = unpacker.unpack("4xHHHH")
+        self.pending_len, self.pending_nparams, self.current_len, self.current_nparams = unpacker.unpack("=4xHHHH")
         unpacker.pad("c")
         self.pending_filter_name = xcffib.List(unpacker, "c", self.pending_len)
         unpacker.pad("i")

--- a/test/generator/record.py
+++ b/test/generator/record.py
@@ -13,7 +13,7 @@ class Range8(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.first, self.last = unpacker.unpack("BB")
+        self.first, self.last = unpacker.unpack("=BB")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -33,7 +33,7 @@ class Range16(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.first, self.last = unpacker.unpack("HH")
+        self.first, self.last = unpacker.unpack("=HH")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -88,7 +88,7 @@ class Range(xcffib.Struct):
         self.device_events = Range8(unpacker)
         unpacker.pad(Range8)
         self.errors = Range8(unpacker)
-        self.client_started, self.client_died = unpacker.unpack("BB")
+        self.client_started, self.client_died = unpacker.unpack("=BB")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()

--- a/test/generator/render.py
+++ b/test/generator/render.py
@@ -13,7 +13,7 @@ class COLOR(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.red, self.green, self.blue, self.alpha = unpacker.unpack("HHHH")
+        self.red, self.green, self.blue, self.alpha = unpacker.unpack("=HHHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -35,7 +35,7 @@ class RECTANGLE(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.x, self.y, self.width, self.height = unpacker.unpack("hhHH")
+        self.x, self.y, self.width, self.height = unpacker.unpack("=hhHH")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()

--- a/test/generator/request_reply.py
+++ b/test/generator/request_reply.py
@@ -10,7 +10,7 @@ class STR(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.name_len, = unpacker.unpack("B")
+        self.name_len, = unpacker.unpack("=B")
         self.name = xcffib.List(unpacker, "c", self.name_len)
         self.bufsize = unpacker.offset - base
     def pack(self):
@@ -31,7 +31,7 @@ class ListExtensionsReply(xcffib.Reply):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Reply.__init__(self, unpacker)
         base = unpacker.offset
-        self.names_len, = unpacker.unpack("xB2x4x24x")
+        self.names_len, = unpacker.unpack("=xB2x4x24x")
         self.names = xcffib.List(unpacker, STR, self.names_len)
         self.bufsize = unpacker.offset - base
 class ListExtensionsCookie(xcffib.Cookie):

--- a/test/generator/struct.py
+++ b/test/generator/struct.py
@@ -10,7 +10,7 @@ class AxisInfo(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.resolution, self.minimum, self.maximum = unpacker.unpack("Iii")
+        self.resolution, self.minimum, self.maximum = unpacker.unpack("=Iii")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -31,7 +31,7 @@ class ValuatorInfo(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.class_id, self.len, self.axes_len, self.mode, self.motion_size = unpacker.unpack("BBBBI")
+        self.class_id, self.len, self.axes_len, self.mode, self.motion_size = unpacker.unpack("=BBBBI")
         self.axes = xcffib.List(unpacker, AxisInfo, self.axes_len)
         self.bufsize = unpacker.offset - base
     def pack(self):

--- a/test/generator/switch.py
+++ b/test/generator/switch.py
@@ -10,7 +10,7 @@ class INT64(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.hi, self.lo = unpacker.unpack("iI")
+        self.hi, self.lo = unpacker.unpack("=iI")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -30,7 +30,7 @@ class GetPropertyReply(xcffib.Reply):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Reply.__init__(self, unpacker)
         base = unpacker.offset
-        self.num_items, self.format = unpacker.unpack("xx2x4xIB")
+        self.num_items, self.format = unpacker.unpack("=xx2x4xIB")
         if self.format & PropertyFormat._8Bits:
             self.data8 = xcffib.List(unpacker, "B", self.num_items)
         if self.format & PropertyFormat._16Bits:
@@ -47,7 +47,7 @@ class GetPropertyWithPadReply(xcffib.Reply):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Reply.__init__(self, unpacker)
         base = unpacker.offset
-        self.num_items, self.format = unpacker.unpack("xx2x4xIB")
+        self.num_items, self.format = unpacker.unpack("=xx2x4xIB")
         self.names = xcffib.List(unpacker, "B", self.num_items)
         if self.format & PropertyFormat._8Bits:
             unpacker.pad("B")

--- a/test/generator/type_pad.py
+++ b/test/generator/type_pad.py
@@ -10,7 +10,7 @@ class CHARINFO(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes = unpacker.unpack("hhhhhH")
+        self.left_side_bearing, self.right_side_bearing, self.character_width, self.ascent, self.descent, self.attributes = unpacker.unpack("=hhhhhH")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -34,7 +34,7 @@ class FONTPROP(xcffib.Struct):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Struct.__init__(self, unpacker)
         base = unpacker.offset
-        self.name, self.value = unpacker.unpack("II")
+        self.name, self.value = unpacker.unpack("=II")
         self.bufsize = unpacker.offset - base
     def pack(self):
         buf = io.BytesIO()
@@ -54,12 +54,12 @@ class ListFontsWithInfoReply(xcffib.Reply):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
         xcffib.Reply.__init__(self, unpacker)
         base = unpacker.offset
-        self.name_len, = unpacker.unpack("xB2x4x")
+        self.name_len, = unpacker.unpack("=xB2x4x")
         self.min_bounds = CHARINFO(unpacker)
-        unpacker.unpack("4x")
+        unpacker.unpack("=4x")
         unpacker.pad(CHARINFO)
         self.max_bounds = CHARINFO(unpacker)
-        self.min_char_or_byte2, self.max_char_or_byte2, self.default_char, self.properties_len, self.draw_direction, self.min_byte1, self.max_byte1, self.all_chars_exist, self.font_ascent, self.font_descent, self.replies_hint = unpacker.unpack("4xHHHHBBBBhhI")
+        self.min_char_or_byte2, self.max_char_or_byte2, self.default_char, self.properties_len, self.draw_direction, self.min_byte1, self.max_byte1, self.all_chars_exist, self.font_ascent, self.font_descent, self.replies_hint = unpacker.unpack("=4xHHHHBBBBhhI")
         unpacker.pad(FONTPROP)
         self.properties = xcffib.List(unpacker, FONTPROP, self.properties_len)
         unpacker.pad("c")


### PR DESCRIPTION
While profiling qtile, I noticed a lot of allocations:

    8   xcffib/__init__.py:106                   4.4 KiB
        size = struct.calcsize(fmt)

this is because we rely on unpack() to prefix structs with =, instead of doing it in the generator. Let's just do it in the generator, so we don't need these allocations at all.