### PR TITLE
ci: use 3.14 for free-threaded builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "pypy3.10"]
+                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14-dev", "3.14t-dev", "pypy3.10"]
                 xcbver: [xcb-proto-1.16.0, xcb-proto-1.17.0, master]
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
cffi 2.0.0 notes:

    Add CPython free-threaded support (3.14t+ only) - huge thanks to the
    folks at Quansight Labs for all the work to get this one sorted!

https://github.com/python-cffi/cffi/releases/tag/v2.0.0

This Used To Work on 3.13t, but maybe that was accidental. Anyway, let's switch to running on 3.14t.